### PR TITLE
Handle non-present files for computing cache key

### DIFF
--- a/hooks/pre-command
+++ b/hooks/pre-command
@@ -31,7 +31,7 @@ compute_tag() {
   while IFS='=' read -r name _ ; do
     if [[ $name =~ ^(BUILDKITE_PLUGIN_DOCKER_ECR_CACHE_CACHE_ON_[0-9]+) ]] ; then
       local sha=($(sha1sum "${!name}"))
-      sums="${sums}${sha}"
+      sums="${sums}${sha:-''}"
     fi
   done < <(env | sort)
   echo "${sums}" | sha1sum | cut -c-7


### PR DESCRIPTION
Currently plugin fails when asked (via `cache-on` opt) to use file that doesn't exist for cache:

```
sha1sum: package-lock.json: No such file or directory
/var/lib/buildkite-agent/plugins/github-com-seek-oss-docker-ecr-cache-buildkite-plugin-v0-0-3/hooks/pre-command: line 34: sha: unbound variable
```

However, there're use cases when it's not known if files be there or not. E.g. commonly used pipelines that consume this plugin, that expect either package-lock.json or yarn.lock be present.

There still will a warning in stderr, but plugin will gracefully handle this situation.