### PR TITLE
Add an optional `target` property.

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,21 @@ steps:
       - docker#v2.0.0
 ```
 
+## Specifying a target step
+
+A [multi-stage Docker build](https://docs.docker.com/develop/develop-images/multistage-build/) can be used to reduce an application container to just its runtime dependencies.
+However, this stripped down container may not have the environment necessary for running CI commands such as tests or linting.
+Instead, the `target` property can be used to specify an intermediate build stage to run commands against:
+
+```yml
+steps:
+  - command: 'cargo test'
+    plugins:
+      - seek-oss/docker-ecr-cache#v1.0.0:
+          target: build-deps
+      - docker#v2.0.0
+```
+
 # Tests
 
 To run the tests of this plugin, run

--- a/hooks/pre-command
+++ b/hooks/pre-command
@@ -46,7 +46,7 @@ image_name="$(get_ecr_url ${repository_name}):$(compute_tag ${docker_file})"
 
 target_arg=""
 if [[ ! -z "${BUILDKITE_PLUGIN_DOCKER_ECR_CACHE_TARGET}" ]]; then
-	target_arg="--target ${BUILDKITE_PLUGIN_DOCKER_ECR_CACHE_TARGET}"
+  target_arg="--target ${BUILDKITE_PLUGIN_DOCKER_ECR_CACHE_TARGET}"
 fi
 
 if ! docker pull "${image_name}"; then

--- a/hooks/pre-command
+++ b/hooks/pre-command
@@ -44,9 +44,14 @@ upsert_ecr "${repository_name}"
 docker_file="${BUILDKITE_PLUGIN_DOCKER_ECR_CACHE_DOCKERFILE:-Dockerfile}"
 image_name="$(get_ecr_url ${repository_name}):$(compute_tag ${docker_file})"
 
+target_arg=""
+if [[ ! -z "${BUILDKITE_PLUGIN_DOCKER_ECR_CACHE_TARGET}" ]]; then
+	target_arg="--target ${BUILDKITE_PLUGIN_DOCKER_ECR_CACHE_TARGET}"
+fi
+
 if ! docker pull "${image_name}"; then
   echo "Image not cached, building"
-  docker build . --file "${docker_file}" -t "${image_name}" || exit 1
+  docker build . --file "${docker_file}" -t "${image_name}" ${target_arg} || exit 1
   docker push "${image_name}"
 fi || echo "Not found"
 

--- a/plugin.yml
+++ b/plugin.yml
@@ -11,4 +11,6 @@ configuration:
       type: array
     ecr-name:
       type: string
+    target:
+      type: string
   required: []


### PR DESCRIPTION
A multi-stage Docker build can be used to reduce an application container to just its runtime dependencies.  However, this stripped down container may not have the environment necessary for running CI commands such as tests or linting.  Instead, the `target` property can be used to
specify an intermediate build stage to run commands against.