### PR TITLE
Support --build-arg options

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 # Docker ECR Cache Buildkite Plugin
 
-[![GitHub
-Release](https://img.shields.io/github/release/seek-oss/docker-ecr-cache-buildkite-plugin.svg)](https://github.com/seek-oss/docker-ecr-cache-buildkite-plugin/releases)
+[![GitHub Release](https://img.shields.io/github/release/seek-oss/docker-ecr-cache-buildkite-plugin.svg)](https://github.com/seek-oss/docker-ecr-cache-buildkite-plugin/releases)
 
 A [Buildkite plugin](https://buildkite.com/docs/agent/v3/plugins) to cache
 Docker images in Amazon ECR.
@@ -76,12 +75,13 @@ steps:
 
 ### Specifying a target step
 
-A [multi-stage Docker
-build](https://docs.docker.com/develop/develop-images/multistage-build/) can be
-used to reduce an application container to just its runtime dependencies.
-However, this stripped down container may not have the environment necessary for
-running CI commands such as tests or linting. Instead, the `target` property can
-be used to specify an intermediate build stage to run commands against:
+A [multi-stage Docker build] can be used to reduce an application container to
+just its runtime dependencies. However, this stripped down container may not
+have the environment necessary for running CI commands such as tests or linting.
+Instead, the `target` property can be used to specify an intermediate build
+stage to run commands against:
+
+[multi-stage docker build]: https://docs.docker.com/develop/develop-images/multistage-build/
 
 ```yaml
 steps:
@@ -94,10 +94,10 @@ steps:
 
 ### Specifying build args
 
-[Build-time
-variables](https://docs.docker.com/engine/reference/commandline/build/#set-build-time-variables---build-arg)
-are supported, either with an explicit value, or without one to propagate an
-environment variable from the pipeline step:
+[Build-time variables] are supported, either with an explicit value, or without
+one to propagate an environment variable from the pipeline step:
+
+[build-time variables]: https://docs.docker.com/engine/reference/commandline/build/#set-build-time-variables---build-arg
 
 ```dockerfile
 FROM bash

--- a/README.md
+++ b/README.md
@@ -1,90 +1,127 @@
-# Docker ECR Cache
+# Docker ECR Cache Buildkite Plugin
 
-A [Buildkite plugin](https://buildkite.com/docs/agent/v3/plugins) to build and cache entire docker images in ECR.
+[![GitHub
+Release](https://img.shields.io/github/release/seek-oss/docker-ecr-cache-buildkite-plugin.svg)](https://github.com/seek-oss/docker-ecr-cache-buildkite-plugin/releases)
 
-This allows you to define a Dockerfile for your build-time dependencies without worrying about the time it
-takes to build the image. It allows you to re-use entire docker images without worrying about layer caching, and/or pruning
-layers as changes are made to your containers.
+A [Buildkite plugin](https://buildkite.com/docs/agent/v3/plugins) to cache
+Docker images in Amazon ECR.
 
-An ECR repository to store the built docker image will be created for you, if one doesn't already exist.
+This allows you to define a Dockerfile for your build-time dependencies without
+worrying about the time it takes to build the image. It allows you to re-use
+entire Docker images without worrying about layer caching, and/or pruning layers
+as changes are made to your containers.
 
-# Example
+An ECR repository to store the built Docker image will be created for you, if
+one doesn't already exist.
 
-## Basic Usage
+## Example
 
-Dockerfile
-```
+### Basic usage
+
+```dockerfile
 FROM bash
+
 RUN echo "my expensive build step"
 ```
 
-```yml
+```yaml
 steps:
   - command: 'echo wow'
     plugins:
-      - seek-oss/docker-ecr-cache#v1.1.1
-      - docker#v2.0.0
+      - seek-oss/docker-ecr-cache#v1.1.3
+      - docker#v3.0.1
 ```
 
-## Caching NPM Packages
+### Caching npm packages
 
-This plugin can be used to effectively cache `node_modules` between builds without worrying abbout
-docker layer cache invalidation. You do this by hinting when the image should be re-built.
+This plugin can be used to effectively cache `node_modules` between builds
+without worrying about Docker layer cache invalidation. You do this by hinting
+when the image should be re-built.
 
-Dockerfile
-```
-FROM node:8
+```dockerfile
+FROM node:10-alpine
+
 WORKDIR /workdir
+
 COPY package.json package-lock.json /workdir
+
 # this step downloads the internet
 RUN npm install
 ```
 
-```yml
+```yaml
 steps:
   - command: 'npm test'
     plugins:
-      - seek-oss/docker-ecr-cache#v1.1.1:
+      - seek-oss/docker-ecr-cache#v1.1.3:
           cache-on:
             - package-lock.json
-      - docker#v2.0.0
+      - docker#v3.0.1:
+          volumes:
+            - /workdir/node_modules
 ```
 
-## Using Another Dockerfile
+### Using another Dockerfile
 
 It's possible to specify the Dockerfile to use by:
 
-```yml
+```yaml
 steps:
   - command: 'echo wow'
     plugins:
-      - seek-oss/docker-ecr-cache#v1.1.1:
+      - seek-oss/docker-ecr-cache#v1.1.3:
           dockerfile: my-dockerfile
-      - docker#v2.0.0
+      - docker#v3.0.1
 ```
 
-## Specifying a target step
+### Specifying a target step
 
-A [multi-stage Docker build](https://docs.docker.com/develop/develop-images/multistage-build/) can be used to reduce an application container to just its runtime dependencies.
-However, this stripped down container may not have the environment necessary for running CI commands such as tests or linting.
-Instead, the `target` property can be used to specify an intermediate build stage to run commands against:
+A [multi-stage Docker
+build](https://docs.docker.com/develop/develop-images/multistage-build/) can be
+used to reduce an application container to just its runtime dependencies.
+However, this stripped down container may not have the environment necessary for
+running CI commands such as tests or linting. Instead, the `target` property can
+be used to specify an intermediate build stage to run commands against:
 
-```yml
+```yaml
 steps:
   - command: 'cargo test'
     plugins:
-      - seek-oss/docker-ecr-cache#v1.1.1:
+      - seek-oss/docker-ecr-cache#v1.1.3:
           target: build-deps
-      - docker#v2.0.0
+      - docker#v3.0.1
 ```
 
-# Tests
+### Specifying build args
 
-To run the tests of this plugin, run
-```sh
-docker-compose run --rm tests
+[Build-time
+variables](https://docs.docker.com/engine/reference/commandline/build/#set-build-time-variables---build-arg)
+are supported, either with an explicit value, or without one to propagate an
+environment variable from the pipeline step:
+
+```dockerfile
+FROM bash
+
+ARG ARG_1
+ARG ARG_2
+
+RUN echo "${ARG_1}"
+RUN echo "${ARG_2}"
 ```
 
-# License
+```yaml
+steps:
+  - command: 'echo amaze'
+    env:
+      ARG_1: wow
+    plugins:
+      - seek-oss/docker-ecr-cache#v1.1.3:
+          build-args:
+            - ARG_1
+            - ARG_2=such
+      - docker#v3.0.1
+```
+
+## License
 
 MIT (see [LICENSE](LICENSE))

--- a/hooks/pre-command
+++ b/hooks/pre-command
@@ -92,7 +92,7 @@ read_build_args
 
 if ! docker pull "${image}:${tag}"; then
   echo '--- Building image'
-  docker build . --file "${docker_file}" --tag "${image}:${tag}" "${build_args[@]}" "${target_args[@]}" || exit 1
+  docker build . --file "${docker_file}" --tag "${image}:${tag}" ${build_args[@]+"${build_args[@]}"} ${target_args[@]+"${target_args[@]}"} || exit 1
   docker tag "${image}:${tag}" "${image}:latest"
 
   echo "--- Pushing tag ${tag}"

--- a/hooks/pre-command
+++ b/hooks/pre-command
@@ -26,35 +26,29 @@ upsert_ecr() {
 }
 
 read_build_args() {
-  if read_list_property 'BUILD_ARGS'; then
-    for arg in "${result[@]}"; do
-      build_args+=('--build-arg' "${arg}")
-    done
-  fi
+  read_list_property 'BUILD_ARGS'
+  for arg in ${result[@]+"${result[@]}"}; do
+    build_args+=('--build-arg' "${arg}")
+  done
 }
 
 # read a plugin property of type [array, string] into a Bash array. Buildkite
 # exposes a string value at BUILDKITE_PLUGIN_{NAME}_{KEY}, and array values at
 # BUILDKITE_PLUGIN_{NAME}_{KEY}_{IDX}.
 read_list_property() {
-  local prefix="BUILDKITE_PLUGIN_DOCKER_ECR_CACHE_${1}"
-  local property="${prefix}_0"
+  local base_name="BUILDKITE_PLUGIN_DOCKER_ECR_CACHE_${1}"
 
   result=()
 
-  if [[ -n ${!property:-} ]]; then
-    local i=0
-    local property="${prefix}_${i}"
-
-    while [[ -n ${!property:-} ]]; do
-      result+=("${!property}")
-
-      i=$((i+1))
-      property="${prefix}_${i}"
-    done
-  elif [[ -n ${!prefix:-} ]]; then
-    result+=("${!prefix}")
+  if [[ -n ${!base_name:-} ]]; then
+    result+=("${!base_name}")
   fi
+
+  while IFS='=' read -r item_name _; do
+    if [[ ${item_name} =~ ^(${base_name}_[0-9]+) ]]; then
+      result+=("${!item_name}")
+    fi
+  done < <(env | sort)
 
   [[ ${#result[@]} -gt 0 ]] || return 1
 }
@@ -65,11 +59,10 @@ compute_tag() {
 
   sums="$(sha1sum "${docker_file}")"
 
-  if read_list_property 'CACHE_ON'; then
-    for file in "${result[@]}"; do
-      sums="${sums}$(sha1sum "${file}")"
-    done
-  fi
+  read_list_property 'CACHE_ON'
+  for file in ${result[@]+"${result[@]}"}; do
+    sums="${sums}$(sha1sum "${file}")"
+  done
 
   echo "${sums}" | sha1sum | cut -c-7
 }

--- a/hooks/pre-command
+++ b/hooks/pre-command
@@ -59,9 +59,19 @@ compute_tag() {
 
   sums="$(sha1sum "${docker_file}")"
 
+  read_list_property 'BUILD_ARGS'
+  for arg in ${result[@]+"${result[@]}"}; do
+    # include underlying environment variable
+    if [[ ${arg} != *=* ]]; then
+      arg+="=${!arg:-}"
+    fi
+
+    sums+="$(echo "${arg}" | sha1sum)"
+  done
+
   read_list_property 'CACHE_ON'
   for file in ${result[@]+"${result[@]}"}; do
-    sums="${sums}$(sha1sum "${file}")"
+    sums+="$(sha1sum "${file}")"
   done
 
   echo "${sums}" | sha1sum | cut -c-7

--- a/hooks/pre-command
+++ b/hooks/pre-command
@@ -49,8 +49,6 @@ read_list_property() {
       result+=("${!item_name}")
     fi
   done < <(env | sort)
-
-  [[ ${#result[@]} -gt 0 ]] || return 1
 }
 
 compute_tag() {

--- a/hooks/pre-command
+++ b/hooks/pre-command
@@ -25,17 +25,52 @@ upsert_ecr() {
   fi
 }
 
+read_build_args() {
+  if read_list_property 'BUILD_ARGS'; then
+    for arg in "${result[@]}"; do
+      build_args+=('--build-arg' "${arg}")
+    done
+  fi
+}
+
+# read a plugin property of type [array, string] into a Bash array. Buildkite
+# exposes a string value at BUILDKITE_PLUGIN_{NAME}_{KEY}, and array values at
+# BUILDKITE_PLUGIN_{NAME}_{KEY}_{IDX}.
+read_list_property() {
+  local prefix="BUILDKITE_PLUGIN_DOCKER_ECR_CACHE_${1}"
+  local property="${prefix}_0"
+
+  result=()
+
+  if [[ -n ${!property:-} ]]; then
+    local i=0
+    local property="${prefix}_${i}"
+
+    while [[ -n ${!property:-} ]]; do
+      result+=("${!property}")
+
+      i=$((i+1))
+      property="${prefix}_${i}"
+    done
+  elif [[ -n ${!prefix:-} ]]; then
+    result+=("${!prefix}")
+  fi
+
+  [[ ${#result[@]} -gt 0 ]] || return 1
+}
+
 compute_tag() {
   local docker_file="$1"
   local sums
 
   sums="$(sha1sum "${docker_file}")"
 
-  while IFS='=' read -r name _ ; do
-    if [[ ${name} =~ ^(BUILDKITE_PLUGIN_DOCKER_ECR_CACHE_CACHE_ON_[0-9]+) ]] ; then
-      sums="${sums}$(sha1sum "${!name}")"
-    fi
-  done < <(env | sort)
+  if read_list_property 'CACHE_ON'; then
+    for file in "${result[@]}"; do
+      sums="${sums}$(sha1sum "${file}")"
+    done
+  fi
+
   echo "${sums}" | sha1sum | cut -c-7
 }
 
@@ -52,9 +87,12 @@ if [[ -n ${BUILDKITE_PLUGIN_DOCKER_ECR_CACHE_TARGET:-} ]]; then
   target_args+=('--target' "${BUILDKITE_PLUGIN_DOCKER_ECR_CACHE_TARGET}")
 fi
 
+build_args=()
+read_build_args
+
 if ! docker pull "${image}:${tag}"; then
   echo '--- Building image'
-  docker build . --file "${docker_file}" --tag "${image}:${tag}" "${target_args[@]}" || exit 1
+  docker build . --file "${docker_file}" --tag "${image}:${tag}" "${build_args[@]}" "${target_args[@]}" || exit 1
   docker tag "${image}:${tag}" "${image}:latest"
 
   echo "--- Pushing tag ${tag}"

--- a/hooks/pre-command
+++ b/hooks/pre-command
@@ -92,7 +92,13 @@ read_build_args
 
 if ! docker pull "${image}:${tag}"; then
   echo '--- Building image'
-  docker build . --file "${docker_file}" --tag "${image}:${tag}" ${build_args[@]+"${build_args[@]}"} ${target_args[@]+"${target_args[@]}"} || exit 1
+  docker build \
+  --file "${docker_file}" \
+  --tag "${image}:${tag}" \
+  ${build_args[@]+"${build_args[@]}"} \
+  ${target_args[@]+"${target_args[@]}"} \
+  . || exit 1
+
   docker tag "${image}:${tag}" "${image}:latest"
 
   echo "--- Pushing tag ${tag}"

--- a/plugin.yml
+++ b/plugin.yml
@@ -1,14 +1,16 @@
-name: docker-ecr-cache
-description: Plugin for building and caching images to AWS ECR
+name: Docker ECR Cache
+description: Cache Docker images in Amazon ECR
 author: https://github.com/seek-oss
 requirements:
   - docker
 configuration:
   properties:
+    build-args:
+      type: [array, string]
+    cache-on:
+      type: [array, string]
     dockerfile:
       type: string
-    cache-on:
-      type: array
     ecr-name:
       type: string
     target:


### PR DESCRIPTION
Add `build-args` property that maps to `docker build --build-arg` options.
(Should I call it `args`?)

Side effects:

- Allow string `cache-on: just-one-file`
- Mess around with the doco
- Fix v1.1.2 blowing up when `target` property is omitted

---

Idea is that this should be possible:

```dockerfile
FROM node

WORKDIR /workdir

RUN echo '//registry.npmjs.org/:_authToken=${NPM_READ_TOKEN}' > .npmrc

COPY package.json package-lock.json ./

ARG NPM_READ_TOKEN

RUN NPM_READ_TOKEN=${NPM_READ_TOKEN} npm install
```

```yaml
steps:
  - command: npm test
    plugins:
      - seek-oss/aws-sm#v2.0.0:
          env:
            NPM_READ_TOKEN: super-secret-secret-id
      - seek-oss/docker-ecr-cache#v1.1.3:
          build-args: NPM_READ_TOKEN
          cache-on: package-lock.json
```
