### PR TITLE
Ignore errors when setting ECR lifecycle policy

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ RUN echo "my expensive build step"
 steps:
   - command: 'echo wow'
     plugins:
-      - seek-oss/docker-ecr-cache#v1.1.4
+      - seek-oss/docker-ecr-cache#v1.1.5
       - docker#v3.0.1
 ```
 
@@ -52,7 +52,7 @@ RUN npm install
 steps:
   - command: 'npm test'
     plugins:
-      - seek-oss/docker-ecr-cache#v1.1.4:
+      - seek-oss/docker-ecr-cache#v1.1.5:
           cache-on:
             - package-lock.json
       - docker#v3.0.1:
@@ -68,7 +68,7 @@ It's possible to specify the Dockerfile to use by:
 steps:
   - command: 'echo wow'
     plugins:
-      - seek-oss/docker-ecr-cache#v1.1.4:
+      - seek-oss/docker-ecr-cache#v1.1.5:
           dockerfile: my-dockerfile
       - docker#v3.0.1
 ```
@@ -87,7 +87,7 @@ stage to run commands against:
 steps:
   - command: 'cargo test'
     plugins:
-      - seek-oss/docker-ecr-cache#v1.1.4:
+      - seek-oss/docker-ecr-cache#v1.1.5:
           target: build-deps
       - docker#v3.0.1
 ```
@@ -115,7 +115,7 @@ steps:
     env:
       ARG_1: wow
     plugins:
-      - seek-oss/docker-ecr-cache#v1.1.4:
+      - seek-oss/docker-ecr-cache#v1.1.5:
           build-args:
             - ARG_1
             - ARG_2=such
@@ -132,7 +132,7 @@ optionally use a custom repository name:
 steps:
   - command: 'echo wow'
     plugins:
-      - seek-oss/docker-ecr-cache#v1.1.4:
+      - seek-oss/docker-ecr-cache#v1.1.5:
           ecr-name: my-unique-repository-name
       - docker#v3.0.1
 ```

--- a/hooks/pre-command
+++ b/hooks/pre-command
@@ -26,9 +26,14 @@ upsert_ecr() {
 
   dir="$(cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd)"
 
+  # Always set the lifecycle policy to update repositories automatically
+  # created before PR #9.
+  #
+  # When using a custom repository with a restricted Buildkite role this might
+  # not succeed. Ignore the error and let the build continue.
   aws ecr put-lifecycle-policy \
   --repository-name "${repository_name}" \
-  --lifecycle-policy-text "file://${dir}/../ecr/lifecycle-policy.json"
+  --lifecycle-policy-text "file://${dir}/../ecr/lifecycle-policy.json" || true
 }
 
 read_build_args() {


### PR DESCRIPTION
Because the previous `upsert_ecr` didn't perform any operations if the ECR repository existed it was possible to "bring your own" ECR repository. For example, this build:

https://buildkite.com/arret/arret/builds/490#9ff9b724-80e2-40d2-a835-eecff8885773

Used a clickopsed ECR with a custom lifecycle policy. This allowed the agent to have `ECRAccessPolicy: PowerUser` to limit its permissions. However, the change in #9 broke this by unconditionally updating the policy in an attempt to fix previously autocreated repositories.

Fix by just ignoring the error. It will still appear in the output but it won't break the build.