### PR TITLE
Use subdirectory (if any) of the Dockerfile as the build context

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ RUN echo "my expensive build step"
 steps:
   - command: 'echo wow'
     plugins:
-      - seek-oss/docker-ecr-cache#v1.1.5
+      - seek-oss/docker-ecr-cache#v1.1.6
       - docker#v3.0.1
 ```
 
@@ -52,7 +52,7 @@ RUN npm install
 steps:
   - command: 'npm test'
     plugins:
-      - seek-oss/docker-ecr-cache#v1.1.5:
+      - seek-oss/docker-ecr-cache#v1.1.6:
           cache-on:
             - package-lock.json
       - docker#v3.0.1:
@@ -68,10 +68,12 @@ It's possible to specify the Dockerfile to use by:
 steps:
   - command: 'echo wow'
     plugins:
-      - seek-oss/docker-ecr-cache#v1.1.5:
+      - seek-oss/docker-ecr-cache#v1.1.6:
           dockerfile: my-dockerfile
       - docker#v3.0.1
 ```
+
+The subdirectory containing the Dockerfile is the path used for the build's context.
 
 ### Specifying a target step
 
@@ -87,7 +89,7 @@ stage to run commands against:
 steps:
   - command: 'cargo test'
     plugins:
-      - seek-oss/docker-ecr-cache#v1.1.5:
+      - seek-oss/docker-ecr-cache#v1.1.6:
           target: build-deps
       - docker#v3.0.1
 ```
@@ -115,7 +117,7 @@ steps:
     env:
       ARG_1: wow
     plugins:
-      - seek-oss/docker-ecr-cache#v1.1.5:
+      - seek-oss/docker-ecr-cache#v1.1.6:
           build-args:
             - ARG_1
             - ARG_2=such
@@ -132,7 +134,7 @@ optionally use a custom repository name:
 steps:
   - command: 'echo wow'
     plugins:
-      - seek-oss/docker-ecr-cache#v1.1.5:
+      - seek-oss/docker-ecr-cache#v1.1.6:
           ecr-name: my-unique-repository-name
       - docker#v3.0.1
 ```

--- a/hooks/pre-command
+++ b/hooks/pre-command
@@ -93,6 +93,7 @@ upsert_ecr "${repository_name}"
 docker_file="${BUILDKITE_PLUGIN_DOCKER_ECR_CACHE_DOCKERFILE:-Dockerfile}"
 image="$(get_ecr_url "${repository_name}")"
 tag="$(compute_tag "${docker_file}")"
+context=$(dirname "${docker_file}")
 
 target_args=()
 if [[ -n ${BUILDKITE_PLUGIN_DOCKER_ECR_CACHE_TARGET:-} ]]; then
@@ -109,7 +110,7 @@ if ! docker pull "${image}:${tag}"; then
   --tag "${image}:${tag}" \
   ${build_args[@]+"${build_args[@]}"} \
   ${target_args[@]+"${target_args[@]}"} \
-  . || exit 1
+  "${context}" || exit 1
 
   docker tag "${image}:${tag}" "${image}:latest"
 


### PR DESCRIPTION
This enables support for Dockerfiles that aren't in the root directory (eg: in monorepos). By using the subdirectory containing the Dockerfile as the build context, .dockerignore and COPY commands work relative to the Dockerfile, rather than the root of the repo.

This is a backward incompatible change that will break COPY commands that are currently specified relative to the repo root, rather than the Dockerfile subdirectory. I've checked existing usages and haven't been able to find any such cases.