### PR TITLE
Replace 10 image ECR lifecycle policy with max-age-days

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,8 +164,8 @@ cached image from ECR, or to build and push a new image for subsequent builds to
 use.
 
 The plugin handles the creation of a dedicated ECR repository for the pipeline
-it runs in. To save on [ECR storage costs], a [lifecycle policy] is
-automatically applied to limit the repository to the last 10 pushed images. By default, images will remain cached for up to 30 days so that images get a chance to apply patches.
+it runs in. To save on [ECR storage costs] and give images a chance to update/patch, a [lifecycle policy] is
+automatically applied to expire images after 30 days (configurable via `max-age-days`).
 
 [ecr storage costs]: https://aws.amazon.com/ecr/pricing/
 [lifecycle policy]: https://docs.aws.amazon.com/AmazonECR/latest/userguide/LifecyclePolicies.html

--- a/hooks/pre-command
+++ b/hooks/pre-command
@@ -25,6 +25,8 @@ upsert_ecr() {
     aws ecr create-repository --repository-name "${repository_name}"
   fi
 
+  # As of May 2019 ECR lifecycle policies can only have one rule that targets "any"
+  # The expire-* tag is to work around this limitation
   policy_text=$(cat <<EOF
 {
   "rules": [
@@ -44,7 +46,8 @@ upsert_ecr() {
       "rulePriority": 2,
       "description": "Expire images older than ${max_age_days} days",
       "selection": {
-        "tagStatus": "any",
+        "tagStatus": "tagged",
+        "tagPrefixList": ["expire-"],
         "countType": "sinceImagePushed",
         "countUnit": "days",
         "countNumber": ${max_age_days}
@@ -147,8 +150,17 @@ if ! docker pull "${image}:${tag}"; then
 
   docker tag "${image}:${tag}" "${image}:latest"
 
+  # tag the image with an expire- prefix so the lifecycle policy will fire
+  max_age_seconds=$(($max_age_days * 86400))
+  expiry_seconds=$(($(date +%s) + $max_age_seconds))
+  expire_tag="expire-${expiry_seconds}"
+  docker tag "${image}:${tag}" "${image}:${expire_tag}"
+
   echo "--- Pushing tag ${tag}"
   docker push "${image}:${tag}"
+
+  echo "--- Pushing tag ${expire_tag}"
+  docker push "${image}:${expire_tag}"
 
   echo "--- Pushing tag latest"
   docker push "${image}:latest"

--- a/hooks/pre-command
+++ b/hooks/pre-command
@@ -26,28 +26,15 @@ upsert_ecr() {
   fi
 
   # As of May 2019 ECR lifecycle policies can only have one rule that targets "any"
-  # The expire-* tag is to work around this limitation
+  # The hash-* tag is to work around this limitation
   policy_text=$(cat <<EOF
 {
   "rules": [
     {
       "rulePriority": 1,
-      "description": "Keep up to 10 total images",
-      "selection": {
-        "tagStatus": "any",
-        "countType": "imageCountMoreThan",
-        "countNumber": 10
-      },
-      "action": {
-        "type": "expire"
-      }
-    },
-    {
-      "rulePriority": 2,
       "description": "Expire images older than ${max_age_days} days",
       "selection": {
-        "tagStatus": "tagged",
-        "tagPrefixList": ["expire-"],
+        "tagStatus": "any",
         "countType": "sinceImagePushed",
         "countUnit": "days",
         "countNumber": ${max_age_days}
@@ -55,7 +42,20 @@ upsert_ecr() {
       "action": {
         "type": "expire"
       }
-    }
+    },
+    {
+      "rulePriority": 2,
+      "description": "Keep up to 10 total images",
+      "selection": {
+        "tagStatus": "tagged",
+        "tagPrefixList": ["hash-"],
+        "countType": "imageCountMoreThan",
+        "countNumber": 10
+      },
+      "action": {
+        "type": "expire"
+      }
+    },
   ]
 }
 EOF
@@ -128,7 +128,7 @@ max_age_days="${BUILDKITE_PLUGIN_DOCKER_ECR_CACHE_MAX_AGE_DAYS:-30}"
 upsert_ecr "${repository_name}" "${max_age_days}"
 docker_file="${BUILDKITE_PLUGIN_DOCKER_ECR_CACHE_DOCKERFILE:-Dockerfile}"
 image="$(get_ecr_url "${repository_name}")"
-tag="$(compute_tag "${docker_file}")"
+tag="hash-$(compute_tag "${docker_file}")"
 context=$(dirname "${docker_file}")
 
 target_args=()
@@ -150,17 +150,8 @@ if ! docker pull "${image}:${tag}"; then
 
   docker tag "${image}:${tag}" "${image}:latest"
 
-  # tag the image with an expire- prefix so the lifecycle policy will fire
-  max_age_seconds=$(($max_age_days * 86400))
-  expiry_seconds=$(($(date +%s) + $max_age_seconds))
-  expire_tag="expire-${expiry_seconds}"
-  docker tag "${image}:${tag}" "${image}:${expire_tag}"
-
   echo "--- Pushing tag ${tag}"
   docker push "${image}:${tag}"
-
-  echo "--- Pushing tag ${expire_tag}"
-  docker push "${image}:${expire_tag}"
 
   echo "--- Pushing tag latest"
   docker push "${image}:latest"

--- a/hooks/pre-command
+++ b/hooks/pre-command
@@ -26,7 +26,7 @@ upsert_ecr() {
   fi
 
   # As of May 2019 ECR lifecycle policies can only have one rule that targets "any"
-  # The hash-* tag is to work around this limitation
+  # Due to this limitation, only the max_age policy is applied
   policy_text=$(cat <<EOF
 {
   "rules": [
@@ -42,20 +42,7 @@ upsert_ecr() {
       "action": {
         "type": "expire"
       }
-    },
-    {
-      "rulePriority": 2,
-      "description": "Keep up to 10 total images",
-      "selection": {
-        "tagStatus": "tagged",
-        "tagPrefixList": ["hash-"],
-        "countType": "imageCountMoreThan",
-        "countNumber": 10
-      },
-      "action": {
-        "type": "expire"
-      }
-    },
+    }
   ]
 }
 EOF
@@ -128,7 +115,7 @@ max_age_days="${BUILDKITE_PLUGIN_DOCKER_ECR_CACHE_MAX_AGE_DAYS:-30}"
 upsert_ecr "${repository_name}" "${max_age_days}"
 docker_file="${BUILDKITE_PLUGIN_DOCKER_ECR_CACHE_DOCKERFILE:-Dockerfile}"
 image="$(get_ecr_url "${repository_name}")"
-tag="hash-$(compute_tag "${docker_file}")"
+tag="$(compute_tag "${docker_file}")"
 context=$(dirname "${docker_file}")
 
 target_args=()

--- a/tests/run.bats
+++ b/tests/run.bats
@@ -55,8 +55,8 @@ pre_command_hook="$PWD/hooks/pre-command"
     "login -u AWS -p 1234 https://1234567891012.dkr.ecr.ap-southeast-2.amazonaws.com : echo logging in to docker" \
     "pull : echo not found && false" \
     "build * : echo building docker image" \
-    "tag ${repository_uri}:hash-deadbee ${repository_uri}:latest : echo tagged latest" \
-    "push ${repository_uri}:hash-deadbee : echo pushed deadbeef" \
+    "tag ${repository_uri}:deadbee ${repository_uri}:latest : echo tagged latest" \
+    "push ${repository_uri}:deadbee : echo pushed deadbeef" \
     "push ${repository_uri}:latest : echo pushed latest"
 
   stub sha1sum \

--- a/tests/run.bats
+++ b/tests/run.bats
@@ -23,7 +23,8 @@ pre_command_hook="$PWD/hooks/pre-command"
     "pull : echo pulled image"
 
   stub sha1sum \
-    "Dockerfile : echo 'sha1sum(Dockerfile)'"
+    "Dockerfile : echo 'sha1sum(Dockerfile)'" \
+    ": echo sha1sum"
 
   run "${pre_command_hook}"
 
@@ -38,3 +39,46 @@ pre_command_hook="$PWD/hooks/pre-command"
   unstub sha1sum
 }
 
+@test "Builds new images with tags" {
+  export BUILDKITE_ORGANIZATION_SLUG="example-org"
+  export BUILDKITE_PIPELINE_SLUG="example-pipeline"
+  local expected_repository_name="build-cache/example-org/example-pipeline"
+  local repository_uri="1234567891012.dkr.ecr.ap-southeast-2.amazonaws.com/${expected_repository_name}"
+
+  stub aws \
+    "ecr get-login --no-include-email : echo docker login -u AWS -p 1234 https://1234567891012.dkr.ecr.ap-southeast-2.amazonaws.com" \
+    "ecr describe-repositories --repository-names ${expected_repository_name} --output text --query repositories[0].registryId : echo looked up repository" \
+    "ecr put-lifecycle-policy * : echo put lifecycle policy" \
+    "ecr describe-repositories --repository-names ${expected_repository_name} --output text --query repositories[0].repositoryUri : echo ${repository_uri}"
+
+  stub docker \
+    "login -u AWS -p 1234 https://1234567891012.dkr.ecr.ap-southeast-2.amazonaws.com : echo logging in to docker" \
+    "pull : echo not found && false" \
+    "build * : echo building docker image" \
+    "tag ${repository_uri}:deadbee ${repository_uri}:latest : echo tagged latest" \
+    "tag ${repository_uri}:deadbee * : echo tagged expire" \
+    "push ${repository_uri}:deadbee : echo pushed deadbeef" \
+    "push * : echo pushed expire" \
+    "push ${repository_uri}:latest : echo pushed latest"
+
+  stub sha1sum \
+    "Dockerfile : echo 'sha1sum(Dockerfile)'" \
+    ": echo deadbeef"
+
+  run "${pre_command_hook}"
+
+  assert_success
+  assert_output --partial "logging in to docker"
+  assert_output --partial "looked up repository"
+  assert_output --partial "building docker image"
+  assert_output --partial "put lifecycle policy"
+  assert_output --partial "tagged latest"
+  assert_output --partial "tagged expire"
+  assert_output --partial "pushed deadbeef"
+  assert_output --partial "pushed latest"
+  assert_output --partial "pushed expire"
+
+  unstub aws
+  unstub docker
+  unstub sha1sum
+}

--- a/tests/run.bats
+++ b/tests/run.bats
@@ -55,10 +55,8 @@ pre_command_hook="$PWD/hooks/pre-command"
     "login -u AWS -p 1234 https://1234567891012.dkr.ecr.ap-southeast-2.amazonaws.com : echo logging in to docker" \
     "pull : echo not found && false" \
     "build * : echo building docker image" \
-    "tag ${repository_uri}:deadbee ${repository_uri}:latest : echo tagged latest" \
-    "tag ${repository_uri}:deadbee * : echo tagged expire" \
-    "push ${repository_uri}:deadbee : echo pushed deadbeef" \
-    "push * : echo pushed expire" \
+    "tag ${repository_uri}:hash-deadbee ${repository_uri}:latest : echo tagged latest" \
+    "push ${repository_uri}:hash-deadbee : echo pushed deadbeef" \
     "push ${repository_uri}:latest : echo pushed latest"
 
   stub sha1sum \
@@ -73,10 +71,8 @@ pre_command_hook="$PWD/hooks/pre-command"
   assert_output --partial "building docker image"
   assert_output --partial "put lifecycle policy"
   assert_output --partial "tagged latest"
-  assert_output --partial "tagged expire"
   assert_output --partial "pushed deadbeef"
   assert_output --partial "pushed latest"
-  assert_output --partial "pushed expire"
 
   unstub aws
   unstub docker

--- a/tests/run.bats
+++ b/tests/run.bats
@@ -1,7 +1,7 @@
 #!/usr/bin/env bats
 
-export AWS_STUB_DEBUG=/dev/tty
-export DOCKER_STUB_DEBUG=/dev/tty
+# export AWS_STUB_DEBUG=/dev/tty
+# export DOCKER_STUB_DEBUG=/dev/tty
 
 load "$BATS_PATH/load.bash"
 


### PR DESCRIPTION
Due to limitations with ECR lifecycle policies, this replaces the 10 image limit with a max-days TTL