### PR TITLE
Allow additional build args to be set with additional-build-args

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,19 @@ steps:
       - docker#v3.0.1
 ```
 
+Additional `docker build` arguments be passed via the `additional-build-args` setting:
+
+```yaml
+steps:
+  - command: 'echo amaze'
+    env:
+      ARG_1: wow
+    plugins:
+      - seek-oss/docker-ecr-cache#v1.3.0:
+          additional-build-args: '--ssh= default=\$SSH_AUTH_SOCK'
+      - docker#v3.0.1
+```
+
 ### Specifying an ECR repository name
 
 The plugin pushes and pulls Docker images to and from an ECR repository named

--- a/hooks/pre-command
+++ b/hooks/pre-command
@@ -134,6 +134,7 @@ if ! docker pull "${image}:${tag}"; then
   docker build \
   --file "${docker_file}" \
   --tag "${image}:${tag}" \
+  ${BUILDKITE_PLUGIN_DOCKER_ECR_CACHE_ADDITIONAL_BUILD_ARGS:-} \
   ${build_args[@]+"${build_args[@]}"} \
   ${target_args[@]+"${target_args[@]}"} \
   "${context}" || exit 1

--- a/plugin.yml
+++ b/plugin.yml
@@ -7,6 +7,8 @@ configuration:
   properties:
     build-args:
       type: [array, string]
+    additional-build-args:
+      type: string
     cache-on:
       type: [array, string]
     dockerfile:


### PR DESCRIPTION
This allows additional arguments to be passed to `docker build` such as the SSH socket or other things. The name is a bit unfortunate as we already have `build-args` which sets `--build-arg` arguments.