### PR TITLE
Support globbing in cache-on property

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,21 @@ steps:
             - /workdir/node_modules
 ```
 
+The `cache-on` property also supports Bash globbing with `globstar`:
+
+```yaml
+steps:
+  - command: 'npm test'
+    plugins:
+      - seek-oss/docker-ecr-cache#v1.1.5:
+          cache-on:
+            - '**/package.json' # monorepo with multiple manifest files
+            - yarn.lock
+      - docker#v3.0.1:
+          volumes:
+            - /workdir/node_modules
+```
+
 ### Using another Dockerfile
 
 It's possible to specify the Dockerfile to use by:

--- a/hooks/pre-command
+++ b/hooks/pre-command
@@ -114,11 +114,17 @@ compute_tag() {
     sums+="$(echo "${arg}" | sha1sum)"
   done
 
+  # expand ** in cache-on properties
+  shopt -s globstar
+
   echoerr 'CACHE_ON'
   read_list_property 'CACHE_ON'
-  for file in ${result[@]+"${result[@]}"}; do
-    echoerr "+ ${file}"
-    sums+="$(sha1sum "${file}")"
+  for glob in ${result[@]+"${result[@]}"}; do
+    echoerr "${glob}"
+    for file in ${glob}; do
+      echoerr "+ ${file}"
+      sums+="$(sha1sum "${file}")"
+    done
   done
 
   echo "${sums}" | sha1sum | cut -c-7

--- a/hooks/pre-command
+++ b/hooks/pre-command
@@ -88,13 +88,25 @@ compute_tag() {
   local docker_file="$1"
   local sums
 
+  echoerr() { echo "$@" 1>&2; }
+
+  echoerr '--- Computing tag'
+
+  echoerr 'DOCKERFILE'
+  echoerr "+ ${docker_file}:${target:-<target>}"
   sums="$(sha1sum "${docker_file}")"
   sums+="$(echo "${target}" | sha1sum)"
+
+  echoerr 'ARCHITECTURE'
+  echoerr "+ $(uname -m)"
   sums+="$(uname -m | sha1sum)"
 
+  echoerr 'BUILD_ARGS'
   read_list_property 'BUILD_ARGS'
   for arg in ${result[@]+"${result[@]}"}; do
-    # include underlying environment variable
+    echoerr "+ ${arg}"
+
+    # include underlying environment variable after echo
     if [[ ${arg} != *=* ]]; then
       arg+="=${!arg:-}"
     fi
@@ -102,8 +114,10 @@ compute_tag() {
     sums+="$(echo "${arg}" | sha1sum)"
   done
 
+  echoerr 'CACHE_ON'
   read_list_property 'CACHE_ON'
   for file in ${result[@]+"${result[@]}"}; do
+    echoerr "+ ${file}"
     sums+="$(sha1sum "${file}")"
   done
 
@@ -118,7 +132,8 @@ upsert_ecr "${repository_name}" "${max_age_days}"
 docker_file="${BUILDKITE_PLUGIN_DOCKER_ECR_CACHE_DOCKERFILE:-Dockerfile}"
 target="${BUILDKITE_PLUGIN_DOCKER_ECR_CACHE_TARGET:-}"
 image="$(get_ecr_url "${repository_name}")"
-tag="$(compute_tag "${docker_file}")"
+exec 3>&1
+tag="$(compute_tag "${docker_file}" 2>&3)"
 context=$(dirname "${docker_file}")
 
 target_args=()


### PR DESCRIPTION
1. Add support for glob patterns to the `cache-on` property:

   ```yaml
   seek-oss/docker-ecr-cache:
     cache-on:
       - '**/package.json'
       - 'important/**.*'
   ```

   Resolves #19.

1. Add verbose logging to aid debugging of cache configs:

   ```yaml
   seek-oss/docker-ecr-cache:
     cache-on:
       - '**/package.json'
       - yarn.lock
     target: dev-deps
   ```

   ```text
   --- Computing tag
   DOCKERFILE
   + Dockerfile:dev-deps
   ARCHITECTURE
   + x86_64
   BUILD_ARGS
   CACHE_ON
   **/package.json
   + package.json
   + services/a/package.json
   + services/b/package.json
   + services/c/package.json
   yarn.lock
   + yarn.lock
   ```