### PR TITLE
gitattributes so we can easily run tests on Windows

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,5 @@
+* text=auto
+# Shell scripts should be lf to avoid linter confusion docker container vs host mismatches on Windows.
+*.bash text eol=lf
+*.bats text eol=lf
+hooks/pre-command text eol=lf


### PR DESCRIPTION
Windows uses CRLF, which when the git worktree is mounted into the container, breaks bash running those scripts.

I've been working around this so far via

```bash
shopt -s globstar
dos2unix **/*.bash **/*.bats hooks/pre-command
docker-compose run --rm tests
unix2dos **/*.bash **/*.bats hooks/pre-command
```

before committing, but then I had this idea instead.