### PR TITLE
Allow custom context support.

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,12 +115,11 @@ The `context` property can be used to specify a different path.
 
 ```yaml
 steps:
-  - command: 'cargo test'
+  - command: cargo test
     plugins:
-      - seek-oss/docker-ecr-cache#v1.7.0:
+      - seek-oss/docker-ecr-cache#v1.8.0:
           dockerfile: dockerfiles/test/Dockerfile
-          target: build-deps
-          context: "."
+          context: '.'
       - docker#v3.3.0
 ```
 

--- a/README.md
+++ b/README.md
@@ -88,8 +88,6 @@ steps:
       - docker#v3.3.0
 ```
 
-The subdirectory containing the Dockerfile is the path used for the build's context.
-
 ### Specifying a target step
 
 A [multi-stage Docker build] can be used to reduce an application container to
@@ -106,6 +104,23 @@ steps:
     plugins:
       - seek-oss/docker-ecr-cache#v1.7.0:
           target: build-deps
+      - docker#v3.3.0
+```
+
+### Specifying build context
+
+The subdirectory containing the Dockerfile is the path used for the build's context by default.
+
+The `context` property can be used to specify a different path.
+
+```yaml
+steps:
+  - command: 'cargo test'
+    plugins:
+      - seek-oss/docker-ecr-cache#v1.7.0:
+          dockerfile: dockerfiles/test/Dockerfile
+          target: build-deps
+          context: "."
       - docker#v3.3.0
 ```
 

--- a/hooks/pre-command
+++ b/hooks/pre-command
@@ -178,7 +178,8 @@ export_env_variable="${BUILDKITE_PLUGIN_DOCKER_ECR_CACHE_EXPORT_ENV_VARIABLE:-"B
 image="$(get_ecr_url "${repository_name}")"
 exec 3>&1
 tag="$(compute_tag "${docker_file}" 2>&3)"
-context=$(dirname "${docker_file}")
+dockerfile_folder=$(dirname "${docker_file}")
+context="${BUILDKITE_PLUGIN_DOCKER_ECR_CACHE_CONTEXT:-${dockerfile_folder}}"
 
 target_args=()
 if [[ -n ${target} ]]; then

--- a/hooks/pre-command
+++ b/hooks/pre-command
@@ -15,7 +15,7 @@ export_env_variable="${BUILDKITE_PLUGIN_DOCKER_ECR_CACHE_EXPORT_ENV_VARIABLE:-"B
 exec 3>&1
 tag="$(compute_tag "${docker_file}" 2>&3)"
 docker_file_dir="$(dirname "${docker_file}")"
-context="${BUILDKITE_PLUGIN_DOCKER_ECR_CACHE_CONTEXT:-${docker_file_dir}}"
+context="${BUILDKITE_PLUGIN_DOCKER_ECR_CACHE_CONTEXT:-"${docker_file_dir}"}"
 
 build_args=()
 read_build_args

--- a/plugin.yml
+++ b/plugin.yml
@@ -23,4 +23,6 @@ configuration:
       type: number
     export-env-variable:
       type: string
+    context:
+      type: string
   required: []


### PR DESCRIPTION
I commonly use nested folders that contain different Dockerfiles for various versions/purposes.  When using this structure setting the build context to the subdirectory containing the Dockerfile produces undesirable behavior.

This PR adds a 'context' property which can be used to override this behavior.  The previous default behavior is unchanged.