### PR TITLE
Allow Dockerfile to be written inline

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,23 @@ steps:
       - docker#v3.3.0
 ```
 
+Alternatively, Dockerfile can be embedded inline:
+
+```yaml
+steps:
+  - command: echo wow
+    plugins:
+      - seek-oss/docker-ecr-cache#v1.9.0:
+          dockerfile-inline: |
+            FROM node:16-alpine
+            WORKDIR /workdir
+            COPY package.json package-lock.json /workdir
+            RUN npm install
+
+
+      - docker#v3.3.0
+```
+
 ### Specifying a target step
 
 A [multi-stage Docker build] can be used to reduce an application container to

--- a/hooks/pre-command
+++ b/hooks/pre-command
@@ -9,12 +9,21 @@ source "$(dirname "${BASH_SOURCE[0]}")/lib/${BUILDKITE_PLUGIN_DOCKER_ECR_CACHE_R
 login
 configure_registry_for_image_if_necessary
 image="$(get_registry_url)"
-docker_file="${BUILDKITE_PLUGIN_DOCKER_ECR_CACHE_DOCKERFILE:-"Dockerfile"}"
+if [ -n "${BUILDKITE_PLUGIN_DOCKER_ECR_CACHE_DOCKERFILE_INLINE-}" ]
+then
+  [-n "${BUILDKITE_PLUGIN_DOCKER_ECR_CACHE_DOCKERFILE:-}" ] &&
+    log_fatal "Cannot specify both 'dockerfile' and 'dockerfile-inline'."
+  docker_file="$(mktemp)"
+  echo "$BUILDKITE_PLUGIN_DOCKER_ECR_CACHE_DOCKERFILE_INLINE" > "$docker_file"
+  docker_file_dir="."
+else
+  docker_file="${BUILDKITE_PLUGIN_DOCKER_ECR_CACHE_DOCKERFILE:-"Dockerfile"}"
+  docker_file_dir="$(dirname "${docker_file}")"
+fi
 target="${BUILDKITE_PLUGIN_DOCKER_ECR_CACHE_TARGET:-}"
 export_env_variable="${BUILDKITE_PLUGIN_DOCKER_ECR_CACHE_EXPORT_ENV_VARIABLE:-"BUILDKITE_PLUGIN_DOCKER_IMAGE"}"
 exec 3>&1
 tag="$(compute_tag "${docker_file}" 2>&3)"
-docker_file_dir="$(dirname "${docker_file}")"
 context="${BUILDKITE_PLUGIN_DOCKER_ECR_CACHE_CONTEXT:-"${docker_file_dir}"}"
 
 build_args=()

--- a/hooks/pre-command
+++ b/hooks/pre-command
@@ -11,7 +11,7 @@ configure_registry_for_image_if_necessary
 image="$(get_registry_url)"
 if [ -n "${BUILDKITE_PLUGIN_DOCKER_ECR_CACHE_DOCKERFILE_INLINE-}" ]
 then
-  [-n "${BUILDKITE_PLUGIN_DOCKER_ECR_CACHE_DOCKERFILE:-}" ] &&
+  [ -n "${BUILDKITE_PLUGIN_DOCKER_ECR_CACHE_DOCKERFILE:-}" ] &&
     log_fatal "Cannot specify both 'dockerfile' and 'dockerfile-inline'."
   docker_file="$(mktemp)"
   echo "$BUILDKITE_PLUGIN_DOCKER_ECR_CACHE_DOCKERFILE_INLINE" > "$docker_file"

--- a/tests/pre-command.bats
+++ b/tests/pre-command.bats
@@ -67,3 +67,31 @@ pre_command_hook="$PWD/hooks/pre-command"
 
   unstub docker
 }
+
+@test "Tags and pushes with inline Dockerfile" {
+  export BUILDKITE_PLUGIN_DOCKER_ECR_CACHE_REGISTRY_PROVIDER="stub"
+  export BUILDKITE_PLUGIN_DOCKER_ECR_CACHE_DOCKERFILE_INLINE="FROM stub"
+  local repository_uri="pretend.host/path/segment/image"
+
+  one_time_mktemp=$(mktemp)
+
+  stub mktemp \
+    "echo $one_time_mktemp"
+
+  stub docker \
+    "pull * : false" \
+    "build --file=$one_time_mktemp * : echo building docker image" \
+    "tag ${repository_uri}:stubbed-computed-tag ${repository_uri}:latest : echo tagged latest" \
+    "push ${repository_uri}:stubbed-computed-tag : echo pushed stubbed-computed-tag" \
+    "push ${repository_uri}:latest : echo pushed latest"
+  run "${pre_command_hook}"
+
+  assert_success
+  assert_line "--- Pulling image"
+  assert_line "--- Building image"
+  assert_line "--- Pushing tag stubbed-computed-tag"
+  assert_line "--- Pushing tag latest"
+
+  unstub mktemp
+  unstub docker
+}

--- a/tests/pre-command.bats
+++ b/tests/pre-command.bats
@@ -92,6 +92,8 @@ pre_command_hook="$PWD/hooks/pre-command"
   assert_line "--- Pushing tag stubbed-computed-tag"
   assert_line "--- Pushing tag latest"
 
+  assert_equal "FROM stub" "$(cat $one_time_mktemp)"
+
   unstub mktemp
   unstub docker
 }


### PR DESCRIPTION
Fixes #32 

Adds new `dockerfile-inline` configuration option to write Dockerfile inside the plugin options.