### PR TITLE
aws cli v2 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -280,7 +280,7 @@ steps:
 
 ### Changing the name of exported variable
 
-By default image name and computed tag are exported to the Docker buildkite plugin env variable `BUILDKITE_PLUGIN_DOCKER_IMAGE`. In order to chain the plugin with a different plugin, this can be changed by specifying a `export-env-variable` parameter:
+By default, image name and computed tag are exported to the Docker buildkite plugin env variable `BUILDKITE_PLUGIN_DOCKER_IMAGE`. In order to chain the plugin with a different plugin, this can be changed by specifying a `export-env-variable` parameter:
 
 ```yaml
 steps:
@@ -308,6 +308,19 @@ steps:
           ecr-tags:
             Key: Value
             Key2: Value2
+      - docker#v3.8.0
+```
+
+#### Specifying a region
+
+By default, the plugin uses the region specified in the `AWS_DEFAULT_REGION` environment variable. If this environment variable is not present, it defaults to the `eu-west-1` region. You can optionally specify the region in which you would like your cache to reside in:
+
+```yaml
+steps:
+  - command: echo wow
+    plugins:
+      - seek-oss/docker-ecr-cache#v1.11.0:
+          region: ap-southeast-2
       - docker#v3.8.0
 ```
 

--- a/hooks/lib/ecr-registry-provider.bash
+++ b/hooks/lib/ecr-registry-provider.bash
@@ -1,12 +1,15 @@
 login() {
-  local account_id=$(aws sts get-caller-identity --query Account --output text)
-  local region=$(get_ecr_region)
+  local account_id
+  local region
+  
+  account_id=$(aws sts get-caller-identity --query Account --output text)
+  region=$(get_ecr_region)
 
   aws ecr get-login-password \
     --region "${region}" \
     | docker login \
     --username AWS \
-    --password-stdin "${account_id}".dkr.ecr."${region}".amazonaws.com
+    --password-stdin "${account_id}.dkr.ecr.${region}.amazonaws.com"
 }
 
 get_ecr_region() {

--- a/hooks/lib/ecr-registry-provider.bash
+++ b/hooks/lib/ecr-registry-provider.bash
@@ -4,7 +4,7 @@ login() {
   if [[ $aws_cli_version =~ ^1 ]]; then
     $(aws ecr get-login --no-include-email)
   else
-    local account_id=$(aws sts get-caller-identity --query "Account" --output text)
+    local account_id=$(aws sts get-caller-identity --query Account --output text)
     local region=$(aws configure get region)
     
     aws ecr get-login-password \

--- a/hooks/lib/ecr-registry-provider.bash
+++ b/hooks/lib/ecr-registry-provider.bash
@@ -1,18 +1,16 @@
 login() {
-  local aws_cli_version=$(aws --version 2>&1 | cut -d " " -f1 | cut -d "/" -f2)
+  local account_id=$(aws sts get-caller-identity --query Account --output text)
+  local region=$(get_ecr_region)
 
-  if [[ $aws_cli_version =~ ^1 ]]; then
-    $(aws ecr get-login --no-include-email)
-  else
-    local account_id=$(aws sts get-caller-identity --query Account --output text)
-    local region=$AWS_REGION
-    
-    aws ecr get-login-password \
-      --region "${region}" \
-      | docker login \
-      --username AWS \
-      --password-stdin "${account_id}".dkr.ecr."${region}".amazonaws.com
-  fi
+  aws ecr get-login-password \
+    --region "${region}" \
+    | docker login \
+    --username AWS \
+    --password-stdin "${account_id}".dkr.ecr."${region}".amazonaws.com
+}
+
+get_ecr_region() {
+  echo "${BUILDKITE_PLUGIN_DOCKER_ECR_CACHE_REGION:-${AWS_DEFAULT_REGION:-eu-west-1}}"
 }
 
 get_registry_url() {

--- a/hooks/lib/ecr-registry-provider.bash
+++ b/hooks/lib/ecr-registry-provider.bash
@@ -5,7 +5,7 @@ login() {
     $(aws ecr get-login --no-include-email)
   else
     local account_id=$(aws sts get-caller-identity --query Account --output text)
-    local region=$(aws configure get region)
+    local region=$AWS_REGION
     
     aws ecr get-login-password \
       --region "${region}" \

--- a/hooks/lib/ecr-registry-provider.bash
+++ b/hooks/lib/ecr-registry-provider.bash
@@ -1,5 +1,18 @@
 login() {
-  $(aws ecr get-login --no-include-email)
+  local aws_cli_version=$(aws --version 2>&1 | cut -d " " -f1 | cut -d "/" -f2)
+
+  if [[ $aws_cli_version =~ ^1 ]]; then
+    $(aws ecr get-login --no-include-email)
+  else
+    local account_id=$(aws sts get-caller-identity --query "Account" --output text)
+    local region=$(aws configure get region)
+    
+    aws ecr get-login-password \
+      --region "${region}" \
+      | docker login \
+      --username AWS \
+      --password-stdin "${account_id}".dkr.ecr."${region}".amazonaws.com
+  fi
 }
 
 get_registry_url() {

--- a/plugin.yml
+++ b/plugin.yml
@@ -31,4 +31,6 @@ configuration:
       type: string
     registry-hostname:
       type: string
+    region:
+      type: string
   required: []

--- a/tests/ecr-registry-provider.bats
+++ b/tests/ecr-registry-provider.bats
@@ -9,18 +9,20 @@ load "$PWD/hooks/lib/ecr-registry-provider.bash"
 
 pre_command_hook="$PWD/hooks/pre-command"
 
-@test "ECR: Applies lifecycle policy to existing repositories" {
+@test "ECR: Applies lifecycle policy to existing repositories with aws-cli v1" {
   export BUILDKITE_ORGANIZATION_SLUG="example-org"
   export BUILDKITE_PIPELINE_SLUG="example-pipeline"
   local expected_repository_name="build-cache/example-org/example-pipeline"
 
   stub aws \
+    "--version : echo 'aws-cli/1.22.58 Python/3.9.2 Linux/5.10.76-linuxkit botocore/1.24.3'" \
     "ecr get-login --no-include-email : echo docker login -u AWS -p 1234 https://1234567891012.dkr.ecr.ap-southeast-2.amazonaws.com" \
     "ecr describe-repositories --repository-names ${expected_repository_name} --output text --query repositories[0].registryId : echo looked up repository" \
     "ecr describe-repositories --repository-names ${expected_repository_name} --output text --query repositories[0].repositoryArn : echo arn:aws:ecr:ap-southeast-2:1234567891012:repository/${expected_repository_name}" \
     "ecr tag-resource * : echo tag existing resource" \
     "ecr put-lifecycle-policy * : echo put lifecycle policy" \
-    "ecr describe-repositories --repository-names ${expected_repository_name} --output text --query repositories[0].repositoryUri : echo https://1234567891012.dkr.ecr.ap-southeast-2.amazonaws.com"
+    "ecr describe-repositories --repository-names ${expected_repository_name} --output text --query repositories[0].repositoryUri : echo https://1234567891012.dkr.ecr.ap-southeast-2.amazonaws.com" 
+    
   stub docker \
     "login -u AWS -p 1234 https://1234567891012.dkr.ecr.ap-southeast-2.amazonaws.com : echo logging in to docker" \
     "pull : echo pulled image"
@@ -45,19 +47,20 @@ pre_command_hook="$PWD/hooks/pre-command"
   unstub sha1sum
 }
 
-@test "ECR: Builds new images with tags" {
+@test "ECR: Builds new images with tags with aws-cli v1" {
   export BUILDKITE_ORGANIZATION_SLUG="example-org"
   export BUILDKITE_PIPELINE_SLUG="example-pipeline"
   local expected_repository_name="build-cache/example-org/example-pipeline"
   local repository_uri="1234567891012.dkr.ecr.ap-southeast-2.amazonaws.com/${expected_repository_name}"
 
   stub aws \
+    "--version : echo 'aws-cli/1.22.58 Python/3.9.2 Linux/5.10.76-linuxkit botocore/1.24.3'" \
     "ecr get-login --no-include-email : echo docker login -u AWS -p 1234 https://1234567891012.dkr.ecr.ap-southeast-2.amazonaws.com" \
     "ecr describe-repositories --repository-names ${expected_repository_name} --output text --query repositories[0].registryId : echo looked up repository" \
     "ecr describe-repositories --repository-names ${expected_repository_name} --output text --query repositories[0].repositoryArn : echo arn:aws:ecr:ap-southeast-2:1234567891012:repository/${expected_repository_name}" \
     "ecr tag-resource * : echo tag existing resource" \
     "ecr put-lifecycle-policy * : echo put lifecycle policy" \
-    "ecr describe-repositories --repository-names ${expected_repository_name} --output text --query repositories[0].repositoryUri : echo ${repository_uri}"
+    "ecr describe-repositories --repository-names ${expected_repository_name} --output text --query repositories[0].repositoryUri : echo ${repository_uri}" 
   stub docker \
     "login -u AWS -p 1234 https://1234567891012.dkr.ecr.ap-southeast-2.amazonaws.com : echo logging in to docker" \
     "pull : echo not found && false" \

--- a/tests/ecr-registry-provider.bats
+++ b/tests/ecr-registry-provider.bats
@@ -9,14 +9,15 @@ load "$PWD/hooks/lib/ecr-registry-provider.bash"
 
 pre_command_hook="$PWD/hooks/pre-command"
 
-@test "ECR: Applies lifecycle policy to existing repositories with aws-cli v1" {
+@test "ECR: Applies lifecycle policy to existing repositories" {
+  export AWS_DEFAULT_REGION="ap-southeast-2"
   export BUILDKITE_ORGANIZATION_SLUG="example-org"
   export BUILDKITE_PIPELINE_SLUG="example-pipeline"
   local expected_repository_name="build-cache/example-org/example-pipeline"
 
   stub aws \
-    "--version : echo 'aws-cli/1.22.58 Python/3.9.2 Linux/5.10.76-linuxkit botocore/1.24.3'" \
-    "ecr get-login --no-include-email : echo docker login -u AWS -p 1234 https://1234567891012.dkr.ecr.ap-southeast-2.amazonaws.com" \
+    "sts get-caller-identity --query Account --output text : echo 1234567891012" \
+    "ecr get-login-password --region ap-southeast-2 : echo secure-ecr-password" \
     "ecr describe-repositories --repository-names ${expected_repository_name} --output text --query repositories[0].registryId : echo looked up repository" \
     "ecr describe-repositories --repository-names ${expected_repository_name} --output text --query repositories[0].repositoryArn : echo arn:aws:ecr:ap-southeast-2:1234567891012:repository/${expected_repository_name}" \
     "ecr tag-resource * : echo tag existing resource" \
@@ -24,7 +25,7 @@ pre_command_hook="$PWD/hooks/pre-command"
     "ecr describe-repositories --repository-names ${expected_repository_name} --output text --query repositories[0].repositoryUri : echo https://1234567891012.dkr.ecr.ap-southeast-2.amazonaws.com" 
     
   stub docker \
-    "login -u AWS -p 1234 https://1234567891012.dkr.ecr.ap-southeast-2.amazonaws.com : echo logging in to docker" \
+    "login --username AWS --password-stdin 1234567891012.dkr.ecr.ap-southeast-2.amazonaws.com : echo logging in to docker" \
     "pull : echo pulled image"
 
   stub sha1sum \
@@ -47,22 +48,24 @@ pre_command_hook="$PWD/hooks/pre-command"
   unstub sha1sum
 }
 
-@test "ECR: Builds new images with tags with aws-cli v1" {
+@test "ECR: Builds new images with tags" {
+  export AWS_DEFAULT_REGION="ap-southeast-2"
   export BUILDKITE_ORGANIZATION_SLUG="example-org"
   export BUILDKITE_PIPELINE_SLUG="example-pipeline"
   local expected_repository_name="build-cache/example-org/example-pipeline"
   local repository_uri="1234567891012.dkr.ecr.ap-southeast-2.amazonaws.com/${expected_repository_name}"
 
   stub aws \
-    "--version : echo 'aws-cli/1.22.58 Python/3.9.2 Linux/5.10.76-linuxkit botocore/1.24.3'" \
-    "ecr get-login --no-include-email : echo docker login -u AWS -p 1234 https://1234567891012.dkr.ecr.ap-southeast-2.amazonaws.com" \
+    "sts get-caller-identity --query Account --output text : echo 1234567891012" \
+    "ecr get-login-password --region ap-southeast-2 : echo secure-ecr-password" \
     "ecr describe-repositories --repository-names ${expected_repository_name} --output text --query repositories[0].registryId : echo looked up repository" \
     "ecr describe-repositories --repository-names ${expected_repository_name} --output text --query repositories[0].repositoryArn : echo arn:aws:ecr:ap-southeast-2:1234567891012:repository/${expected_repository_name}" \
     "ecr tag-resource * : echo tag existing resource" \
     "ecr put-lifecycle-policy * : echo put lifecycle policy" \
-    "ecr describe-repositories --repository-names ${expected_repository_name} --output text --query repositories[0].repositoryUri : echo ${repository_uri}" 
+    "ecr describe-repositories --repository-names ${expected_repository_name} --output text --query repositories[0].repositoryUri : echo ${repository_uri}" \
+
   stub docker \
-    "login -u AWS -p 1234 https://1234567891012.dkr.ecr.ap-southeast-2.amazonaws.com : echo logging in to docker" \
+    "login --username AWS --password-stdin 1234567891012.dkr.ecr.ap-southeast-2.amazonaws.com : echo logging in to docker" \
     "pull : echo not found && false" \
     "build * : echo building docker image" \
     "tag ${repository_uri}:deadbee ${repository_uri}:latest : echo tagged latest" \
@@ -92,65 +95,71 @@ pre_command_hook="$PWD/hooks/pre-command"
   unstub sha1sum
 }
 
-@test "ECR: Applies lifecycle policy to existing repositories with aws-cli v2" {
-  export AWS_REGION="ap-southeast-2"
+@test "ECR: Uses correct region when region not specified and AWS_DEFAULT_REGION not set" {
   export BUILDKITE_ORGANIZATION_SLUG="example-org"
   export BUILDKITE_PIPELINE_SLUG="example-pipeline"
   local expected_repository_name="build-cache/example-org/example-pipeline"
+  local repository_uri="1234567891012.dkr.ecr.eu-west-1.amazonaws.com/${expected_repository_name}"
 
   stub aws \
-    "--version : echo 'aws-cli/2.4.15 Python/3.9.2 Linux/5.10.76-linuxkit botocore/1.24.3'" \
     "sts get-caller-identity --query Account --output text : echo 1234567891012" \
-    "ecr get-login-password --region ap-southeast-2 : echo secure-ecr-password" \
+    "ecr get-login-password --region eu-west-1 : echo secure-ecr-password" \
     "ecr describe-repositories --repository-names ${expected_repository_name} --output text --query repositories[0].registryId : echo looked up repository" \
-    "ecr describe-repositories --repository-names ${expected_repository_name} --output text --query repositories[0].repositoryArn : echo arn:aws:ecr:ap-southeast-2:1234567891012:repository/${expected_repository_name}" \
+    "ecr describe-repositories --repository-names ${expected_repository_name} --output text --query repositories[0].repositoryArn : echo arn:aws:ecr:eu-west-1:1234567891012:repository/${expected_repository_name}" \
     "ecr tag-resource * : echo tag existing resource" \
     "ecr put-lifecycle-policy * : echo put lifecycle policy" \
-    "ecr describe-repositories --repository-names ${expected_repository_name} --output text --query repositories[0].repositoryUri : echo https://1234567891012.dkr.ecr.ap-southeast-2.amazonaws.com" 
-    
+    "ecr describe-repositories --repository-names ${expected_repository_name} --output text --query repositories[0].repositoryUri : echo ${repository_uri}" \
+
   stub docker \
-    "login --username AWS --password-stdin 1234567891012.dkr.ecr.ap-southeast-2.amazonaws.com : echo logging in to docker" \
-    "pull : echo pulled image"
+    "login --username AWS --password-stdin 1234567891012.dkr.ecr.eu-west-1.amazonaws.com : echo logging in to docker" \
+    "pull : echo not found && false" \
+    "build * : echo building docker image" \
+    "tag ${repository_uri}:deadbee ${repository_uri}:latest : echo tagged latest" \
+    "push ${repository_uri}:deadbee : echo pushed deadbeef" \
+    "push ${repository_uri}:latest : echo pushed latest"
 
   stub sha1sum \
     "Dockerfile : echo 'sha1sum(Dockerfile)'" \
     ": echo sha1sum" \
     ": echo sha1sum" \
-    ": echo sha1sum"
+    ": echo deadbeef"
 
   run "${pre_command_hook}"
 
   assert_success
   assert_output --partial "logging in to docker"
-  assert_output --partial "pulled image"
   assert_output --partial "looked up repository"
+  assert_output --partial "building docker image"
   assert_output --partial "tag existing resource"
   assert_output --partial "put lifecycle policy"
+  assert_output --partial "tagged latest"
+  assert_output --partial "pushed deadbeef"
+  assert_output --partial "pushed latest"
 
   unstub aws
   unstub docker
   unstub sha1sum
 }
 
-@test "ECR: Builds new images with tags with aws-cli v2" {
-  export AWS_REGION="ap-southeast-2"
+@test "ECR: Uses correct region when region is specified" {
+  export AWS_DEFAULT_REGION="ap-southeast-2"
+  export BUILDKITE_PLUGIN_DOCKER_ECR_CACHE_REGION="ap-southeast-1"
   export BUILDKITE_ORGANIZATION_SLUG="example-org"
   export BUILDKITE_PIPELINE_SLUG="example-pipeline"
   local expected_repository_name="build-cache/example-org/example-pipeline"
-  local repository_uri="1234567891012.dkr.ecr.ap-southeast-2.amazonaws.com/${expected_repository_name}"
+  local repository_uri="1234567891012.dkr.ecr.ap-southeast-1.amazonaws.com/${expected_repository_name}"
 
   stub aws \
-    "--version : echo 'aws-cli/2.4.15 Python/3.9.2 Linux/5.10.76-linuxkit botocore/1.24.3'" \
     "sts get-caller-identity --query Account --output text : echo 1234567891012" \
-    "ecr get-login-password --region ap-southeast-2 : echo secure-ecr-password" \
+    "ecr get-login-password --region ap-southeast-1 : echo secure-ecr-password" \
     "ecr describe-repositories --repository-names ${expected_repository_name} --output text --query repositories[0].registryId : echo looked up repository" \
-    "ecr describe-repositories --repository-names ${expected_repository_name} --output text --query repositories[0].repositoryArn : echo arn:aws:ecr:ap-southeast-2:1234567891012:repository/${expected_repository_name}" \
+    "ecr describe-repositories --repository-names ${expected_repository_name} --output text --query repositories[0].repositoryArn : echo arn:aws:ecr:ap-southeast-1:1234567891012:repository/${expected_repository_name}" \
     "ecr tag-resource * : echo tag existing resource" \
     "ecr put-lifecycle-policy * : echo put lifecycle policy" \
     "ecr describe-repositories --repository-names ${expected_repository_name} --output text --query repositories[0].repositoryUri : echo ${repository_uri}" \
 
   stub docker \
-    "login --username AWS --password-stdin 1234567891012.dkr.ecr.ap-southeast-2.amazonaws.com : echo logging in to docker" \
+    "login --username AWS --password-stdin 1234567891012.dkr.ecr.ap-southeast-1.amazonaws.com : echo logging in to docker" \
     "pull : echo not found && false" \
     "build * : echo building docker image" \
     "tag ${repository_uri}:deadbee ${repository_uri}:latest : echo tagged latest" \

--- a/tests/ecr-registry-provider.bats
+++ b/tests/ecr-registry-provider.bats
@@ -91,3 +91,91 @@ pre_command_hook="$PWD/hooks/pre-command"
   unstub docker
   unstub sha1sum
 }
+
+@test "ECR: Applies lifecycle policy to existing repositories with aws-cli v2" {
+  export BUILDKITE_ORGANIZATION_SLUG="example-org"
+  export BUILDKITE_PIPELINE_SLUG="example-pipeline"
+  local expected_repository_name="build-cache/example-org/example-pipeline"
+
+  stub aws \
+    "--version : echo 'aws-cli/2.4.15 Python/3.9.2 Linux/5.10.76-linuxkit botocore/1.24.3'" \
+    "sts get-caller-identity --query \"Account\" --output text : echo 1234567891012" \
+    "configure get region : echo ap-southeast-2"  \
+    "ecr get-login-password --region ap-southeast-2 : echo secure-ecr-password" \
+    "ecr describe-repositories --repository-names ${expected_repository_name} --output text --query repositories[0].registryId : echo looked up repository" \
+    "ecr describe-repositories --repository-names ${expected_repository_name} --output text --query repositories[0].repositoryArn : echo arn:aws:ecr:ap-southeast-2:1234567891012:repository/${expected_repository_name}" \
+    "ecr tag-resource * : echo tag existing resource" \
+    "ecr put-lifecycle-policy * : echo put lifecycle policy" \
+    "ecr describe-repositories --repository-names ${expected_repository_name} --output text --query repositories[0].repositoryUri : echo https://1234567891012.dkr.ecr.ap-southeast-2.amazonaws.com" 
+    
+  stub docker \
+    "login --username AWS --password-stdin 1234567891012.dkr.ecr.ap-southeast-2.amazonaws.com : echo logging in to docker" \
+    "pull : echo pulled image"
+
+  stub sha1sum \
+    "Dockerfile : echo 'sha1sum(Dockerfile)'" \
+    ": echo sha1sum" \
+    ": echo sha1sum" \
+    ": echo sha1sum"
+
+  run "${pre_command_hook}"
+
+  assert_success
+  assert_output --partial "logging in to docker"
+  assert_output --partial "pulled image"
+  assert_output --partial "looked up repository"
+  assert_output --partial "tag existing resource"
+  assert_output --partial "put lifecycle policy"
+
+  unstub aws
+  unstub docker
+  unstub sha1sum
+}
+
+@test "ECR: Builds new images with tags with aws-cli v2" {
+  export BUILDKITE_ORGANIZATION_SLUG="example-org"
+  export BUILDKITE_PIPELINE_SLUG="example-pipeline"
+  local expected_repository_name="build-cache/example-org/example-pipeline"
+  local repository_uri="1234567891012.dkr.ecr.ap-southeast-2.amazonaws.com/${expected_repository_name}"
+
+  stub aws \
+    "--version : echo 'aws-cli/2.4.15 Python/3.9.2 Linux/5.10.76-linuxkit botocore/1.24.3'" \
+    "sts get-caller-identity --query \"Account\" --output text : echo 1234567891012" \
+    "configure get region : echo ap-southeast-2"  \
+    "ecr get-login-password --region ap-southeast-2 : echo secure-ecr-password" \
+    "ecr describe-repositories --repository-names ${expected_repository_name} --output text --query repositories[0].registryId : echo looked up repository" \
+    "ecr describe-repositories --repository-names ${expected_repository_name} --output text --query repositories[0].repositoryArn : echo arn:aws:ecr:ap-southeast-2:1234567891012:repository/${expected_repository_name}" \
+    "ecr tag-resource * : echo tag existing resource" \
+    "ecr put-lifecycle-policy * : echo put lifecycle policy" \
+    "ecr describe-repositories --repository-names ${expected_repository_name} --output text --query repositories[0].repositoryUri : echo ${repository_uri}" \
+
+  stub docker \
+    "login --username AWS --password-stdin 1234567891012.dkr.ecr.ap-southeast-2.amazonaws.com : echo logging in to docker" \
+    "pull : echo not found && false" \
+    "build * : echo building docker image" \
+    "tag ${repository_uri}:deadbee ${repository_uri}:latest : echo tagged latest" \
+    "push ${repository_uri}:deadbee : echo pushed deadbeef" \
+    "push ${repository_uri}:latest : echo pushed latest"
+
+  stub sha1sum \
+    "Dockerfile : echo 'sha1sum(Dockerfile)'" \
+    ": echo sha1sum" \
+    ": echo sha1sum" \
+    ": echo deadbeef"
+
+  run "${pre_command_hook}"
+
+  assert_success
+  assert_output --partial "logging in to docker"
+  assert_output --partial "looked up repository"
+  assert_output --partial "building docker image"
+  assert_output --partial "tag existing resource"
+  assert_output --partial "put lifecycle policy"
+  assert_output --partial "tagged latest"
+  assert_output --partial "pushed deadbeef"
+  assert_output --partial "pushed latest"
+
+  unstub aws
+  unstub docker
+  unstub sha1sum
+}

--- a/tests/ecr-registry-provider.bats
+++ b/tests/ecr-registry-provider.bats
@@ -93,14 +93,14 @@ pre_command_hook="$PWD/hooks/pre-command"
 }
 
 @test "ECR: Applies lifecycle policy to existing repositories with aws-cli v2" {
+  export AWS_REGION="ap-southeast-2"
   export BUILDKITE_ORGANIZATION_SLUG="example-org"
   export BUILDKITE_PIPELINE_SLUG="example-pipeline"
   local expected_repository_name="build-cache/example-org/example-pipeline"
 
   stub aws \
     "--version : echo 'aws-cli/2.4.15 Python/3.9.2 Linux/5.10.76-linuxkit botocore/1.24.3'" \
-    "sts get-caller-identity --query \"Account\" --output text : echo 1234567891012" \
-    "configure get region : echo ap-southeast-2"  \
+    "sts get-caller-identity --query Account --output text : echo 1234567891012" \
     "ecr get-login-password --region ap-southeast-2 : echo secure-ecr-password" \
     "ecr describe-repositories --repository-names ${expected_repository_name} --output text --query repositories[0].registryId : echo looked up repository" \
     "ecr describe-repositories --repository-names ${expected_repository_name} --output text --query repositories[0].repositoryArn : echo arn:aws:ecr:ap-southeast-2:1234567891012:repository/${expected_repository_name}" \
@@ -133,6 +133,7 @@ pre_command_hook="$PWD/hooks/pre-command"
 }
 
 @test "ECR: Builds new images with tags with aws-cli v2" {
+  export AWS_REGION="ap-southeast-2"
   export BUILDKITE_ORGANIZATION_SLUG="example-org"
   export BUILDKITE_PIPELINE_SLUG="example-pipeline"
   local expected_repository_name="build-cache/example-org/example-pipeline"
@@ -140,8 +141,7 @@ pre_command_hook="$PWD/hooks/pre-command"
 
   stub aws \
     "--version : echo 'aws-cli/2.4.15 Python/3.9.2 Linux/5.10.76-linuxkit botocore/1.24.3'" \
-    "sts get-caller-identity --query \"Account\" --output text : echo 1234567891012" \
-    "configure get region : echo ap-southeast-2"  \
+    "sts get-caller-identity --query Account --output text : echo 1234567891012" \
     "ecr get-login-password --region ap-southeast-2 : echo secure-ecr-password" \
     "ecr describe-repositories --repository-names ${expected_repository_name} --output text --query repositories[0].registryId : echo looked up repository" \
     "ecr describe-repositories --repository-names ${expected_repository_name} --output text --query repositories[0].repositoryArn : echo arn:aws:ecr:ap-southeast-2:1234567891012:repository/${expected_repository_name}" \


### PR DESCRIPTION
Adds support for aws-cli v2, which is installed by default on newer versions of Elastic CI. 

Maintains backwards compatibility with aws-cli v1.17.10 (released in Febuary 2020) or later