### PR TITLE
Add parameter to add additional docker tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -291,6 +291,24 @@ steps:
       - my-custom-plugin#v1.0.0:
 ```
 
+### Specifying tags to apply to the pushed Docker image
+
+By default, the image is tagged with the `latest` tag in addition to the cache key.
+
+By specifying the `tags` parameter you can specify your own set of tags to apply to the image:
+
+```yaml
+steps:
+  - command: echo wow
+    plugins:
+      - seek-oss/docker-ecr-cache#v2.0.0:
+          tags:
+            - latest
+            - build-${BUILDKITE_BUILD_NUMBER}
+```
+
+Specifying your own tags makes it easy to reuse the image later in the pipeline.
+
 ### AWS ECR specific configuration
 
 #### Specifying an ECR repository name

--- a/README.md
+++ b/README.md
@@ -293,7 +293,7 @@ steps:
 
 ### Specifying tags to apply to the pushed Docker image
 
-By default, the image is tagged with the `latest` tag in addition to the cache key.
+The image is tagged with the cache key and`latest`.
 
 By specifying the `tags` parameter you can specify your own set of tags to apply to the image:
 
@@ -303,11 +303,10 @@ steps:
     plugins:
       - seek-oss/docker-ecr-cache#v2.0.0:
           tags:
-            - latest
             - build-${BUILDKITE_BUILD_NUMBER}
 ```
 
-Specifying your own tags makes it easy to reuse the image later in the pipeline.
+These tags are applied *each time the plugin runs*, whether the image is newly built or already exists and was pulled.
 
 ### AWS ECR specific configuration
 

--- a/hooks/pre-command
+++ b/hooks/pre-command
@@ -71,25 +71,25 @@ if ! docker pull "${image}:${tag}"; then
   docker "${image_build_args[@]}" ${BUILDKITE_PLUGIN_DOCKER_ECR_CACHE_ADDITIONAL_BUILD_ARGS:-} "${context}" ||
     log_fatal "^^^ +++" 1
 
-  echo "--- Pushing tags"
-  echo " - ${tag}"
+  docker tag "${image}:${tag}" "${image}:latest"
+
+  echo "--- Pushing tag ${tag}"
   docker push "${image}:${tag}"
 
-  results=()
-  read_list_property 'TAGS'
-  if [ "${#result[*]}" == "0" ]; then
-    echo " - latest"
-    docker tag "${image}:${tag}" "${image}:latest"
-    docker push "${image}:latest"
-  else
-    for other_tag in ${result[@]+"${result[@]}"}; do
-      echo " - ${other_tag}"
-      docker tag "${image}:${tag}" "${image}:${other_tag}"
-      docker push "${image}:${other_tag}"
-    done
-  fi
-
+  echo "--- Pushing tag latest"
+  docker push "${image}:latest"
 fi || echo "Not found"
+
+results=()
+read_list_property 'TAGS'
+if [ "${#result[*]}" != "0" ]; then
+  for extra_tag in ${result[@]+"${result[@]}"}; do
+    echo "--- Pushing extra tags"
+    echo " - ${extra_tag}"
+    docker tag "${image}:${tag}" "${image}:${extra_tag}"
+    docker push "${image}:${extra_tag}"
+  done
+fi
 
 # Support using https://github.com/buildkite-plugins/docker-buildkite-plugin without an image by default
 export ${export_env_variable}="${image}:${tag}"

--- a/hooks/pre-command
+++ b/hooks/pre-command
@@ -71,13 +71,24 @@ if ! docker pull "${image}:${tag}"; then
   docker "${image_build_args[@]}" ${BUILDKITE_PLUGIN_DOCKER_ECR_CACHE_ADDITIONAL_BUILD_ARGS:-} "${context}" ||
     log_fatal "^^^ +++" 1
 
-  docker tag "${image}:${tag}" "${image}:latest"
-
-  echo "--- Pushing tag ${tag}"
+  echo "--- Pushing tags"
+  echo " - ${tag}"
   docker push "${image}:${tag}"
 
-  echo "--- Pushing tag latest"
-  docker push "${image}:latest"
+  results=()
+  read_list_property 'TAGS'
+  if [ "${#result[*]}" == "0" ]; then
+    echo " - latest"
+    docker tag "${image}:${tag}" "${image}:latest"
+    docker push "${image}:latest"
+  else
+    for other_tag in ${result[@]+"${result[@]}"}; do
+      echo " - ${other_tag}"
+      docker tag "${image}:${tag}" "${image}:${other_tag}"
+      docker push "${image}:${other_tag}"
+    done
+  fi
+
 fi || echo "Not found"
 
 # Support using https://github.com/buildkite-plugins/docker-buildkite-plugin without an image by default

--- a/plugin.yml
+++ b/plugin.yml
@@ -33,4 +33,6 @@ configuration:
       type: string
     region:
       type: string
+    tags:
+      type: [array, string]
   required: []


### PR DESCRIPTION
This PR adds a `tags: <list>` parameter to in order to enable tagging of images with additional _docker_ tags.

This is useful if you want to be able to reference the image later in the pipeline e.g. from a `docker-compose` file

Example usage:
```yml
# pipeline.yml

steps:
  - command: echo wow
    plugins:
      - seek-oss/docker-ecr-cache#v2.0.0:
          ecr-name: <repository>
          tags:
            - build-${BUILDKITE_BUILD_NUMBER}
```

```yml
# docker-compose.yml

services:
  test:
    image: <registry>/<repository>:build-${BUILDKITE_BUILD_NUMBER}
    command: npm run test
```