### PR TITLE
Export the environment variables even when skipping pull

### DIFF
--- a/hooks/pre-command
+++ b/hooks/pre-command
@@ -38,53 +38,52 @@ read_secrets
 
 if [ "${BUILDKITE_PLUGIN_DOCKER_ECR_CACHE_SKIP_PULL_FROM_CACHE:-}" == "true" ] && image_exists "$tag"; then
   echo "Image exists, skipping pull"
-  exit 0;
-fi
+else
+  echo "--- Pulling image"
 
-echo "--- Pulling image"
-
-if ! docker pull "${image}:${tag}"; then
-  echo '--- Building image'
-  image_build_args=(
-    "build"
-    "--file=${docker_file}"
-    "--tag=${image}:${tag}"
-  )
-  if [[ -n "${target:-}" ]]; then
-    image_build_args+=(
-      "--target=${target}"
+  if ! docker pull "${image}:${tag}"; then
+    echo '--- Building image'
+    image_build_args=(
+      "build"
+      "--file=${docker_file}"
+      "--tag=${image}:${tag}"
     )
-  fi
-  if [[ "${#build_args[@]}" -gt 0 ]]; then
-    for ba in "${build_args[@]}"; do
+    if [[ -n "${target:-}" ]]; then
       image_build_args+=(
-        "${ba}"
+        "--target=${target}"
       )
-    done
-  fi
-  if [[ "${#secrets_args[@]}" -gt 0 ]]; then
-    export DOCKER_BUILDKIT=1
-    for sa in "${secrets_args[@]}"; do
-      image_build_args+=(
-        "${sa}"
-      )
-    done
-  fi
+    fi
+    if [[ "${#build_args[@]}" -gt 0 ]]; then
+      for ba in "${build_args[@]}"; do
+        image_build_args+=(
+          "${ba}"
+        )
+      done
+    fi
+    if [[ "${#secrets_args[@]}" -gt 0 ]]; then
+      export DOCKER_BUILDKIT=1
+      for sa in "${secrets_args[@]}"; do
+        image_build_args+=(
+          "${sa}"
+        )
+      done
+    fi
 
-  echo "Inside $(pwd), running \`docker ${image_build_args[*]} ${context}\`"
-  # We can't quote BUILDKITE_PLUGIN_DOCKER_ECR_CACHE_ADDITIONAL_BUILD_ARGS, because it's passed here as a string instead of a bash array.
-  # shellcheck disable=SC2086
-  docker "${image_build_args[@]}" ${BUILDKITE_PLUGIN_DOCKER_ECR_CACHE_ADDITIONAL_BUILD_ARGS:-} "${context}" ||
-    log_fatal "^^^ +++" 1
+    echo "Inside $(pwd), running \`docker ${image_build_args[*]} ${context}\`"
+    # We can't quote BUILDKITE_PLUGIN_DOCKER_ECR_CACHE_ADDITIONAL_BUILD_ARGS, because it's passed here as a string instead of a bash array.
+    # shellcheck disable=SC2086
+    docker "${image_build_args[@]}" ${BUILDKITE_PLUGIN_DOCKER_ECR_CACHE_ADDITIONAL_BUILD_ARGS:-} "${context}" ||
+      log_fatal "^^^ +++" 1
 
-  docker tag "${image}:${tag}" "${image}:latest"
+    docker tag "${image}:${tag}" "${image}:latest"
 
-  echo "--- Pushing tag ${tag}"
-  docker push "${image}:${tag}"
+    echo "--- Pushing tag ${tag}"
+    docker push "${image}:${tag}"
 
-  echo "--- Pushing tag latest"
-  docker push "${image}:latest"
-fi || echo "Not found"
+    echo "--- Pushing tag latest"
+    docker push "${image}:latest"
+  fi || echo "Not found"
+fi
 
 # Support using https://github.com/buildkite-plugins/docker-buildkite-plugin without an image by default
 export ${export_env_variable}="${image}:${tag}"


### PR DESCRIPTION
## Description

When `skip-pull-from-cache` is set to `true`, the `BUILDKITE_PLUGIN_DOCKER_IMAGE`, `BUILDKITE_PLUGIN_DOCKER_ECR_CACHE_EXPORT_IMAGE` & `BUILDKITE_PLUGIN_DOCKER_ECR_CACHE_EXPORT_TAG` environment variables are not exported even if the `image` & `tag` variables are available.