### PR TITLE
Set build `--progress` to `plain`

### DIFF
--- a/hooks/pre-command
+++ b/hooks/pre-command
@@ -46,6 +46,7 @@ else
     image_build_args=(
       "build"
       "--file=${docker_file}"
+      "--progress=plain"
       "--tag=${image}:${tag}"
     )
     if [[ -n "${target:-}" ]]; then

--- a/tests/ecr-registry-provider.bats
+++ b/tests/ecr-registry-provider.bats
@@ -67,7 +67,7 @@ pre_command_hook="$PWD/hooks/pre-command"
   stub docker \
     "login --username AWS --password-stdin 1234567891012.dkr.ecr.ap-southeast-2.amazonaws.com : echo logging in to docker" \
     "pull 1234567891012.dkr.ecr.ap-southeast-2.amazonaws.com/build-cache/example-org/example-pipeline:deadbee : echo not found && false" \
-    "build --file=Dockerfile --tag=1234567891012.dkr.ecr.ap-southeast-2.amazonaws.com/build-cache/example-org/example-pipeline:deadbee . : echo building docker image" \
+    "build --file=Dockerfile --progress=plain --tag=1234567891012.dkr.ecr.ap-southeast-2.amazonaws.com/build-cache/example-org/example-pipeline:deadbee . : echo building docker image" \
     "tag ${repository_uri}:deadbee ${repository_uri}:latest : echo tagged latest" \
     "push ${repository_uri}:deadbee : echo pushed deadbee" \
     "push ${repository_uri}:latest : echo pushed latest"
@@ -113,7 +113,7 @@ pre_command_hook="$PWD/hooks/pre-command"
   stub docker \
     "login --username AWS --password-stdin 1234567891012.dkr.ecr.eu-west-1.amazonaws.com : echo logging in to docker" \
     "pull 1234567891012.dkr.ecr.eu-west-1.amazonaws.com/build-cache/example-org/example-pipeline:deadbee : echo not found && false" \
-    "build --file=Dockerfile --tag=1234567891012.dkr.ecr.eu-west-1.amazonaws.com/build-cache/example-org/example-pipeline:deadbee . : echo building docker image" \
+    "build --file=Dockerfile --progress=plain --tag=1234567891012.dkr.ecr.eu-west-1.amazonaws.com/build-cache/example-org/example-pipeline:deadbee . : echo building docker image" \
     "tag ${repository_uri}:deadbee ${repository_uri}:latest : echo tagged latest" \
     "push ${repository_uri}:deadbee : echo pushed deadbee" \
     "push ${repository_uri}:latest : echo pushed latest"
@@ -161,7 +161,7 @@ pre_command_hook="$PWD/hooks/pre-command"
   stub docker \
     "login --username AWS --password-stdin 1234567891012.dkr.ecr.ap-southeast-1.amazonaws.com : echo logging in to docker" \
     "pull 1234567891012.dkr.ecr.ap-southeast-1.amazonaws.com/build-cache/example-org/example-pipeline:deadbee : echo not found && false" \
-    "build --file=Dockerfile --tag=1234567891012.dkr.ecr.ap-southeast-1.amazonaws.com/build-cache/example-org/example-pipeline:deadbee . : echo building docker image" \
+    "build --file=Dockerfile --progress=plain --tag=1234567891012.dkr.ecr.ap-southeast-1.amazonaws.com/build-cache/example-org/example-pipeline:deadbee . : echo building docker image" \
     "tag ${repository_uri}:deadbee ${repository_uri}:latest : echo tagged latest" \
     "push ${repository_uri}:deadbee : echo pushed deadbee" \
     "push ${repository_uri}:latest : echo pushed latest"

--- a/tests/pre-command.bats
+++ b/tests/pre-command.bats
@@ -35,7 +35,7 @@ pre_command_hook="$PWD/hooks/pre-command"
 
   stub docker \
     "pull pretend.host/path/segment/image:stubbed-computed-tag : false" \
-    "build --file=Dockerfile --tag=pretend.host/path/segment/image:stubbed-computed-tag . : exit 242"
+    "build --file=Dockerfile --progress=plain --tag=pretend.host/path/segment/image:stubbed-computed-tag . : exit 242"
 
   run "${pre_command_hook}"
 
@@ -53,7 +53,7 @@ pre_command_hook="$PWD/hooks/pre-command"
 
   stub docker \
     "pull pretend.host/path/segment/image:stubbed-computed-tag : false" \
-    "build --file=Dockerfile --tag=pretend.host/path/segment/image:stubbed-computed-tag . : echo building docker image" \
+    "build --file=Dockerfile --progress=plain --tag=pretend.host/path/segment/image:stubbed-computed-tag . : echo building docker image" \
     "tag ${repository_uri}:stubbed-computed-tag ${repository_uri}:latest : echo tagged latest" \
     "push ${repository_uri}:stubbed-computed-tag : echo pushed stubbed-computed-tag" \
     "push ${repository_uri}:latest : echo pushed latest"
@@ -80,7 +80,7 @@ pre_command_hook="$PWD/hooks/pre-command"
 
   stub docker \
     "pull pretend.host/path/segment/image:stubbed-computed-tag : false" \
-    "build --file=$one_time_mktemp/Dockerfile --tag=pretend.host/path/segment/image:stubbed-computed-tag . : echo building docker image" \
+    "build --file=$one_time_mktemp/Dockerfile --progress=plain --tag=pretend.host/path/segment/image:stubbed-computed-tag . : echo building docker image" \
     "tag ${repository_uri}:stubbed-computed-tag ${repository_uri}:latest : echo tagged latest" \
     "push ${repository_uri}:stubbed-computed-tag : echo pushed stubbed-computed-tag" \
     "push ${repository_uri}:latest : echo pushed latest"


### PR DESCRIPTION
This will make it easier to review build information in the Buildkite UI as lines won't be hidden by escape codes, and prevents TTY progress from clogging up exported build logs.