### PR TITLE
feat: add unhashed-build-args to exclude volatile values from cache key

### DIFF
--- a/hooks/lib/stdlib.bash
+++ b/hooks/lib/stdlib.bash
@@ -20,6 +20,13 @@ read_build_args() {
   done
 }
 
+read_unhashed_build_args() {
+  read_list_property 'UNHASHED_BUILD_ARGS'
+  for arg in ${result[@]+"${result[@]}"}; do
+    unhashed_build_args+=("--build-arg=${arg}")
+  done
+}
+
 read_secrets() {
   read_list_property 'SECRETS'
   for arg in ${result[@]+"${result[@]}"}; do

--- a/hooks/pre-command
+++ b/hooks/pre-command
@@ -33,6 +33,9 @@ context="${BUILDKITE_PLUGIN_DOCKER_ECR_CACHE_CONTEXT:-"${context_dir}"}"
 build_args=()
 read_build_args
 
+unhashed_build_args=()
+read_unhashed_build_args
+
 secrets_args=()
 read_secrets
 
@@ -51,6 +54,13 @@ if ! docker pull "${image}:${tag}"; then
   fi
   if [[ "${#build_args[@]}" -gt 0 ]]; then
     for ba in "${build_args[@]}"; do
+      image_build_args+=(
+        "${ba}"
+      )
+    done
+  fi
+  if [[ "${#unhashed_build_args[@]}" -gt 0 ]]; then
+    for ba in "${unhashed_build_args[@]}"; do
       image_build_args+=(
         "${ba}"
       )

--- a/plugin.yml
+++ b/plugin.yml
@@ -7,6 +7,9 @@ configuration:
   properties:
     build-args:
       type: [array, string]
+    unhashed-build-args:
+      type: [array, string]
+      description: Build args passed to docker build but excluded from the cache key hash (use for volatile values like auth tokens)
     additional-build-args:
       type: string
     cache-on:


### PR DESCRIPTION
IGNORE -- PR created against the wrong repo.