### PR TITLE
Drop default max-age-days from 30 to 7

### DIFF
--- a/README.md
+++ b/README.md
@@ -288,7 +288,7 @@ environment variable if any secrets are present in the configuration.
 
 ### Changing the max cache time
 
-By default images are kept in ECR for up to 30 days. This can be changed by specifying a `max-age-days` parameter:
+By default images are kept in ECR for up to 7 days. This can be changed by specifying a `max-age-days` parameter:
 
 ```yaml
 steps:
@@ -422,7 +422,7 @@ use.
 
 The plugin handles the creation of a dedicated ECR repository for the pipeline
 it runs in. To save on [ECR storage costs] and give images a chance to update/patch, a [lifecycle policy] is
-automatically applied to expire images after 30 days (configurable via `max-age-days`).
+automatically applied to expire images after 7 days (configurable via `max-age-days`).
 
 [ecr storage costs]: https://aws.amazon.com/ecr/pricing/
 [lifecycle policy]: https://docs.aws.amazon.com/AmazonECR/latest/userguide/LifecyclePolicies.html

--- a/hooks/lib/ecr-registry-provider.bash
+++ b/hooks/lib/ecr-registry-provider.bash
@@ -84,7 +84,7 @@ get_ecr_repository_name() {
 configure_registry_for_image_if_necessary() {
   local repository_name
   repository_name="$(get_ecr_repository_name)"
-  local max_age_days="${BUILDKITE_PLUGIN_DOCKER_ECR_CACHE_MAX_AGE_DAYS:-30}"
+  local max_age_days="${BUILDKITE_PLUGIN_DOCKER_ECR_CACHE_MAX_AGE_DAYS:-7}"
   local ecr_tags="$(get_ecr_tags)"
   local num_tags=$(echo $ecr_tags | jq '.tags | length')
 


### PR DESCRIPTION
Reduces stale image exposure. Align with security expectations (7-day cache expiry remains within the 14-day critical SLO window if any fixes are necessary).

- Lower lingering cache-image age by default.
- Reduce long-lived stale build-cache images that contribute to vulnerability management friction.
- Keep behavior simple for teams (no per-repo custom override)

Aiming to update ifecycle defaults for Gantry-managed repositories as well.