### PR TITLE
Embed BuildKit inline cache metadata in built images by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -325,6 +325,48 @@ steps:
           skip-pull-from-cache: true
 ```
 
+### Using the image as a cache source for other builds
+
+Images built by this plugin embed [inline cache metadata] by default, so
+downstream builds can reuse their layers via `--cache-from` — for example with
+the [Docker ECR Publish](https://github.com/seek-oss/docker-ecr-publish-buildkite-plugin)
+plugin:
+
+```yaml
+steps:
+  - plugins:
+      - seek-oss/docker-ecr-publish#v2.4.0:
+          cache-from: ecr://build-cache/my-org/my-pipeline
+          ecr-name: my-repo
+```
+
+This matters because BuildKit's default `docker` driver can only read inline
+cache metadata: without it, `--cache-from` still pulls the image but re-runs
+every layer. On plugin versions that predate this behaviour, pass the build
+arg yourself:
+
+```yaml
+steps:
+  - command: echo wow
+    plugins:
+      - seek-oss/docker-ecr-cache#v2.2.1:
+          additional-build-args: '--build-arg BUILDKIT_INLINE_CACHE=1'
+      - docker#v5.10.0
+```
+
+Set `disable-cache-metadata: true` to opt out of embedding the metadata:
+
+```yaml
+steps:
+  - command: echo wow
+    plugins:
+      - seek-oss/docker-ecr-cache#v3.0.0:
+          disable-cache-metadata: true
+      - docker#v5.10.0
+```
+
+[inline cache metadata]: https://docs.docker.com/build/cache/backends/inline/
+
 ### AWS ECR specific configuration
 
 #### Specifying an ECR repository name

--- a/hooks/pre-command
+++ b/hooks/pre-command
@@ -49,6 +49,13 @@ else
       "--progress=plain"
       "--tag=${image}:${tag}"
     )
+    if [[ "${BUILDKITE_PLUGIN_DOCKER_ECR_CACHE_DISABLE_CACHE_METADATA:-}" != "true" ]]; then
+      # Embed BuildKit cache metadata so downstream builds can reuse this
+      # image via `--cache-from`; the docker driver only reads inline metadata.
+      image_build_args+=(
+        "--build-arg=BUILDKIT_INLINE_CACHE=1"
+      )
+    fi
     if [[ -n "${target:-}" ]]; then
       image_build_args+=(
         "--target=${target}"

--- a/plugin.yml
+++ b/plugin.yml
@@ -35,4 +35,6 @@ configuration:
       type: string
     skip-pull-from-cache:
       type: boolean
+    disable-cache-metadata:
+      type: boolean
   required: []

--- a/tests/ecr-registry-provider.bats
+++ b/tests/ecr-registry-provider.bats
@@ -67,7 +67,7 @@ pre_command_hook="$PWD/hooks/pre-command"
   stub docker \
     "login --username AWS --password-stdin 1234567891012.dkr.ecr.ap-southeast-2.amazonaws.com : echo logging in to docker" \
     "pull 1234567891012.dkr.ecr.ap-southeast-2.amazonaws.com/build-cache/example-org/example-pipeline:deadbee : echo not found && false" \
-    "build --file=Dockerfile --progress=plain --tag=1234567891012.dkr.ecr.ap-southeast-2.amazonaws.com/build-cache/example-org/example-pipeline:deadbee . : echo building docker image" \
+    "build --file=Dockerfile --progress=plain --tag=1234567891012.dkr.ecr.ap-southeast-2.amazonaws.com/build-cache/example-org/example-pipeline:deadbee --build-arg=BUILDKIT_INLINE_CACHE=1 . : echo building docker image" \
     "tag ${repository_uri}:deadbee ${repository_uri}:latest : echo tagged latest" \
     "push ${repository_uri}:deadbee : echo pushed deadbee" \
     "push ${repository_uri}:latest : echo pushed latest"
@@ -113,7 +113,7 @@ pre_command_hook="$PWD/hooks/pre-command"
   stub docker \
     "login --username AWS --password-stdin 1234567891012.dkr.ecr.eu-west-1.amazonaws.com : echo logging in to docker" \
     "pull 1234567891012.dkr.ecr.eu-west-1.amazonaws.com/build-cache/example-org/example-pipeline:deadbee : echo not found && false" \
-    "build --file=Dockerfile --progress=plain --tag=1234567891012.dkr.ecr.eu-west-1.amazonaws.com/build-cache/example-org/example-pipeline:deadbee . : echo building docker image" \
+    "build --file=Dockerfile --progress=plain --tag=1234567891012.dkr.ecr.eu-west-1.amazonaws.com/build-cache/example-org/example-pipeline:deadbee --build-arg=BUILDKIT_INLINE_CACHE=1 . : echo building docker image" \
     "tag ${repository_uri}:deadbee ${repository_uri}:latest : echo tagged latest" \
     "push ${repository_uri}:deadbee : echo pushed deadbee" \
     "push ${repository_uri}:latest : echo pushed latest"
@@ -161,7 +161,7 @@ pre_command_hook="$PWD/hooks/pre-command"
   stub docker \
     "login --username AWS --password-stdin 1234567891012.dkr.ecr.ap-southeast-1.amazonaws.com : echo logging in to docker" \
     "pull 1234567891012.dkr.ecr.ap-southeast-1.amazonaws.com/build-cache/example-org/example-pipeline:deadbee : echo not found && false" \
-    "build --file=Dockerfile --progress=plain --tag=1234567891012.dkr.ecr.ap-southeast-1.amazonaws.com/build-cache/example-org/example-pipeline:deadbee . : echo building docker image" \
+    "build --file=Dockerfile --progress=plain --tag=1234567891012.dkr.ecr.ap-southeast-1.amazonaws.com/build-cache/example-org/example-pipeline:deadbee --build-arg=BUILDKIT_INLINE_CACHE=1 . : echo building docker image" \
     "tag ${repository_uri}:deadbee ${repository_uri}:latest : echo tagged latest" \
     "push ${repository_uri}:deadbee : echo pushed deadbee" \
     "push ${repository_uri}:latest : echo pushed latest"

--- a/tests/pre-command.bats
+++ b/tests/pre-command.bats
@@ -35,7 +35,7 @@ pre_command_hook="$PWD/hooks/pre-command"
 
   stub docker \
     "pull pretend.host/path/segment/image:stubbed-computed-tag : false" \
-    "build --file=Dockerfile --progress=plain --tag=pretend.host/path/segment/image:stubbed-computed-tag . : exit 242"
+    "build --file=Dockerfile --progress=plain --tag=pretend.host/path/segment/image:stubbed-computed-tag --build-arg=BUILDKIT_INLINE_CACHE=1 . : exit 242"
 
   run "${pre_command_hook}"
 
@@ -53,7 +53,7 @@ pre_command_hook="$PWD/hooks/pre-command"
 
   stub docker \
     "pull pretend.host/path/segment/image:stubbed-computed-tag : false" \
-    "build --file=Dockerfile --progress=plain --tag=pretend.host/path/segment/image:stubbed-computed-tag . : echo building docker image" \
+    "build --file=Dockerfile --progress=plain --tag=pretend.host/path/segment/image:stubbed-computed-tag --build-arg=BUILDKIT_INLINE_CACHE=1 . : echo building docker image" \
     "tag ${repository_uri}:stubbed-computed-tag ${repository_uri}:latest : echo tagged latest" \
     "push ${repository_uri}:stubbed-computed-tag : echo pushed stubbed-computed-tag" \
     "push ${repository_uri}:latest : echo pushed latest"
@@ -80,7 +80,7 @@ pre_command_hook="$PWD/hooks/pre-command"
 
   stub docker \
     "pull pretend.host/path/segment/image:stubbed-computed-tag : false" \
-    "build --file=$one_time_mktemp/Dockerfile --progress=plain --tag=pretend.host/path/segment/image:stubbed-computed-tag . : echo building docker image" \
+    "build --file=$one_time_mktemp/Dockerfile --progress=plain --tag=pretend.host/path/segment/image:stubbed-computed-tag --build-arg=BUILDKIT_INLINE_CACHE=1 . : echo building docker image" \
     "tag ${repository_uri}:stubbed-computed-tag ${repository_uri}:latest : echo tagged latest" \
     "push ${repository_uri}:stubbed-computed-tag : echo pushed stubbed-computed-tag" \
     "push ${repository_uri}:latest : echo pushed latest"
@@ -107,4 +107,26 @@ pre_command_hook="$PWD/hooks/pre-command"
 
   assert_success
   assert_line "Image exists, skipping pull"
+}
+
+@test "Omits inline cache metadata when disable-cache-metadata is true" {
+  export BUILDKITE_PLUGIN_DOCKER_ECR_CACHE_REGISTRY_PROVIDER="stub"
+  export BUILDKITE_PLUGIN_DOCKER_ECR_CACHE_DISABLE_CACHE_METADATA="true"
+  local repository_uri="pretend.host/path/segment/image"
+
+  stub docker \
+    "pull pretend.host/path/segment/image:stubbed-computed-tag : false" \
+    "build --file=Dockerfile --progress=plain --tag=pretend.host/path/segment/image:stubbed-computed-tag . : echo building docker image" \
+    "tag ${repository_uri}:stubbed-computed-tag ${repository_uri}:latest : echo tagged latest" \
+    "push ${repository_uri}:stubbed-computed-tag : echo pushed stubbed-computed-tag" \
+    "push ${repository_uri}:latest : echo pushed latest"
+  run "${pre_command_hook}"
+
+  assert_success
+  assert_line "--- Pulling image"
+  assert_line "--- Building image"
+  assert_line "--- Pushing tag stubbed-computed-tag"
+  assert_line "--- Pushing tag latest"
+
+  unstub docker
 }


### PR DESCRIPTION
- Images built by this plugin are meant to be reused as cache sources via `--cache-from` (e.g. by docker-ecr-publish), but BuildKit's default docker driver can only read inline cache metadata, which the plugin never embedded.
- Downstream builds pulled the cache image and then re-ran every layer anyway.
- Changes made:
  - Add `--build-arg BUILDKIT_INLINE_CACHE=1` to the image build by default
  - Add a `disable-cache-metadata: true` opt-out, matching the option name in docker-ecr-publish
  - Document the behaviour in the README, including the `additional-build-args: '--build-arg BUILDKIT_INLINE_CACHE=1'` workaround for older versions